### PR TITLE
Fix bintray release scripts

### DIFF
--- a/.bintray.template
+++ b/.bintray.template
@@ -17,10 +17,10 @@
   [
     { "includePattern": "dist/(.*)/(.*)/osprey\\.(.*)",
       "excludePattern": "dist/latest/(.*)",
-      "uploadPattern": "$1/osprey-$1_$2.$3"
+      "uploadPattern": "osprey/$1/osprey-$1_$2.$3"
     },
     { "includePattern": "dist/latest/(.*)/osprey\\.(.*)",
-      "uploadPattern": "latest/osprey-latest_$1.$2",
+      "uploadPattern": "osprey/latest/osprey-latest_$1.$2",
       "matrixParams": { "override": 1 }
     }
   ],

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ proto :
 git_rev := $(shell git rev-parse --short HEAD)
 git_tag := $(shell git tag --points-at=$(git_rev))
 release_date := $(shell date +%d-%m-%Y)
-latest_git_tag := $(git for-each-ref --format="%(tag)" --sort=-taggerdate refs/tags | grep osprey | head -1)
-latest_git_rev := $(git rev-list -n 1 $(latest_git_tag))
+latest_git_tag := $(shell git for-each-ref --format="%(tag)" --sort=-taggerdate refs/tags | head -1)
+latest_git_rev := $(shell git rev-list --abbrev-commit -n 1 $(latest_git_tag))
 
 prepare-release-bintray :
 ifeq ($(strip $(SKIP_PREPARE_RELEASE_BINTRAY)), )
@@ -109,7 +109,7 @@ else
 		artifact=osprey; \
 		case $$distribution in \
 			windows*) \
-				mv osprey osprey.exe \
+				cp osprey osprey.exe; \
 				artifact=$$artifact.zip; \
 				zip -9 $$artifact osprey.exe; \
 				;; \


### PR DESCRIPTION
- Windows distribution was missing a ';' to break the mv command from the 
  artifact name. 
- Travis bintray upload does not place the files under the package directory 
  by default, so it needs to be added to the upload pattern.
- Fix checks to detect latest release or not. 