### PR TITLE
Osprey can start when dex is unavailable

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -177,6 +177,15 @@ var _ = Describe("E2E", func() {
 				Expect(ospreyconfig.ConfigFile).To(BeAnExistingFile())
 			})
 
+			It("healthcheck should return ok", func() {
+				for _, osprey := range ospreys {
+					resp, err := osprey.CallHealthcheck()
+
+					Expect(err).To(BeNil(), "could not call healthcheck")
+					Expect(resp.StatusCode).To(Equal(200))
+				}
+			})
+
 			Context("kubeconfig file", func() {
 				var (
 					generatedConfig *clientgo.Config

--- a/e2e/ospreytest/fixtures.go
+++ b/e2e/ospreytest/fixtures.go
@@ -86,14 +86,7 @@ func (o *TestOsprey) ToGroupClaims(authInfo *clientgo.AuthInfo) ([]string, error
 	return extractClaims(token)
 }
 
-func extractClaims(token jwt.JWT) (groups []string, err error) {
-	claimedGroups := token.Claims().Get("groups")
-	for _, group := range claimedGroups.([]interface{}) {
-		groups = append(groups, group.(string))
-	}
-	return groups, err
-}
-
+// CallHealthcheck returns the current status of osprey's healthcheck as an http response and error
 func (o *TestOsprey) CallHealthcheck() (*http.Response, error) {
 	ospreyHealthCheckURL := fmt.Sprintf("%s/healthz", o.URL)
 	req, err := http.NewRequest(http.MethodGet, ospreyHealthCheckURL, nil)
@@ -101,4 +94,12 @@ func (o *TestOsprey) CallHealthcheck() (*http.Response, error) {
 
 	resp, err := httpClient.Do(req)
 	return resp, err
+}
+
+func extractClaims(token jwt.JWT) (groups []string, err error) {
+	claimedGroups := token.Claims().Get("groups")
+	for _, group := range claimedGroups.([]interface{}) {
+		groups = append(groups, group.(string))
+	}
+	return groups, err
 }

--- a/e2e/ospreytest/fixtures.go
+++ b/e2e/ospreytest/fixtures.go
@@ -5,8 +5,11 @@ import (
 
 	"io/ioutil"
 
+	"net/http"
+
 	"github.com/SermoDigital/jose/jws"
 	"github.com/SermoDigital/jose/jwt"
+	"github.com/sky-uk/osprey/common/web"
 	"github.com/sky-uk/osprey/server/osprey"
 	clientgo "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -89,4 +92,13 @@ func extractClaims(token jwt.JWT) (groups []string, err error) {
 		groups = append(groups, group.(string))
 	}
 	return groups, err
+}
+
+func (o *TestOsprey) CallHealthcheck() (*http.Response, error) {
+	ospreyHealthCheckURL := fmt.Sprintf("%s/healthz", o.URL)
+	req, err := http.NewRequest(http.MethodGet, ospreyHealthCheckURL, nil)
+	httpClient, err := web.NewTLSClient(o.CertFile)
+
+	resp, err := httpClient.Do(req)
+	return resp, err
 }

--- a/server/osprey/server.go
+++ b/server/osprey/server.go
@@ -84,7 +84,7 @@ func (o *osprey) issuerURL() string {
 }
 
 func (o *osprey) GetAccessToken(ctx context.Context, username, password string) (*pb.LoginResponse, error) {
-	loginForm, err := o.requestAuth(username, password, ctx)
+	loginForm, err := o.requestAuth(ctx, username, password)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (o *osprey) GetAccessToken(ctx context.Context, username, password string) 
 	return response, nil
 }
 
-func (o *osprey) requestAuth(username, password string, ctx context.Context) (*loginForm, error) {
+func (o *osprey) requestAuth(ctx context.Context, username, password string) (*loginForm, error) {
 	if username == "" || password == "" {
 		return nil, status.Error(codes.Unauthenticated, "invalid credentials")
 	}

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -78,6 +78,7 @@ type Server struct {
 func (s *Server) RegisterService(service osprey.Osprey) {
 	s.mux.Handle("/access-token", handleAccessToken(service))
 	s.mux.Handle("/callback", handleCallback(service))
+	s.mux.Handle("/healthz", handleHealthcheck())
 }
 
 func setup(server *Server) *http.Server {
@@ -116,6 +117,13 @@ func handleCallback(osprey osprey.Osprey) http.HandlerFunc {
 			err = status.Error(codes.InvalidArgument, "Method not implemented")
 		}
 		handleResponse(w, response, err)
+	}
+}
+
+func handleHealthcheck() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "Health check passed!")
 	}
 }
 


### PR DESCRIPTION
Osprey will now start when dex is not running/unavailable/unreachable.

Also introduced `/healthz` endpoint for osprey server which can be used
as a liveness probe in the deployment.

Migrating over from https://github.com/sky-uk/core-infrastructure/pull/1896