### PR TITLE
Add support for loading CA data from base64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Release 1.1.0
+- Adds support for `certificate-authority-data` in client config.
+
 # Release 1.0.0
 - Includes client commands: `user`, `user login`, `user logout`.
 - Includes server command: `serve`.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ The client uses a yaml configuration file. It's recommended location is:
 # Uses system's CA certs if absent (only in unix systems).
 # certificate-authority: /tmp/osprey-238319279/cluster_ca.crt
 
+# Alternatively, base64-encoded PEM format certificate.
+# This will override certificate-authority if specified.
+# Same caveat for Windows systems applies.
+# certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk5vdCB2YWxpZAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+
 # Named map of target osprey servers to contact for access-tokens
 targets:
   # Target osprey's environment name.
@@ -161,6 +166,11 @@ targets:
     # CA cert to use for HTTPS connections to osprey.
     # Uses system's CA certs if absent (only in unix systems).
     # certificate-authority: /tmp/osprey-238319279/cluster_ca.crt
+
+    # Alternatively, base64-encoded PEM format certificate.
+    # This will override certificate-authority if specified.
+    # Same caveat for Windows systems applies.
+    # certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk5vdCB2YWxpZAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
 
 ```
 

--- a/client/config.go
+++ b/client/config.go
@@ -89,6 +89,9 @@ func LoadConfig(path string) (*Config, error) {
 			return nil, fmt.Errorf("failed to load global CA certificate: %v", err)
 		}
 		config.CertificateAuthorityData = certData
+	} else if config.CertificateAuthorityData != "" {
+    // CA is ignored if CAData is present
+		config.CertificateAuthority = ""
 	}
 
 	for name, target := range config.Targets {
@@ -99,6 +102,9 @@ func LoadConfig(path string) (*Config, error) {
 				return nil, fmt.Errorf("failed to load CA certificate for target %s: %v", name, err)
 			}
 			target.CertificateAuthorityData = certData
+		} else if target.CertificateAuthorityData != "" {
+      // CA is ignored if CAData is present
+			target.CertificateAuthority = ""
 		}
 	}
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -50,7 +50,7 @@ func login(cmd *cobra.Command, args []string) {
 	}
 	success := true
 	for name, target := range ospreyconfig.Targets {
-		c := client.NewClient(target.Server, ospreyconfig.CertificateAuthority, target.CertificateAuthority)
+		c := client.NewClient(target.Server, ospreyconfig.CertificateAuthorityData, target.CertificateAuthorityData)
 		tokenData, err := c.GetAccessToken(credentials)
 		if err != nil {
 			if state, ok := status.FromError(err); ok && state.Code() == codes.Unauthenticated {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -55,7 +55,6 @@ func init() {
 
 func serve(cmd *cobra.Command, args []string) {
 	var err error
-
 	issuerCAData, err := webClient.LoadTLSCert(issuerCA)
 	if err != nil {
 		log.Fatalf("Failed to load issuerCA: %v", err)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -55,7 +55,18 @@ func init() {
 
 func serve(cmd *cobra.Command, args []string) {
 	var err error
-	httpClient, err := webClient.NewTLSClient(issuerCA, tlsCert)
+
+	issuerCAData, err := webClient.LoadTLSCert(issuerCA)
+	if err != nil {
+		log.Fatalf("Failed to load issuerCA: %v", err)
+	}
+
+	tlsCertData, err := webClient.LoadTLSCert(tlsCert)
+	if err != nil {
+		log.Fatalf("Failed to load tls-cert: %v", err)
+	}
+
+	httpClient, err := webClient.NewTLSClient(issuerCAData, tlsCertData)
 	if err != nil {
 		log.Fatal("Failed to create http client")
 	}

--- a/common/web/client.go
+++ b/common/web/client.go
@@ -16,13 +16,10 @@ import (
 // base64-encoded string.
 func LoadTLSCert(path string) (string, error) {
 	fileData, err := ioutil.ReadFile(path)
-
 	if err != nil {
 		return "", fmt.Errorf("failed to read certificate file %q: %v", path, err)
 	}
-
 	certData := base64.StdEncoding.EncodeToString(fileData)
-
 	return certData, nil
 }
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -30,6 +30,8 @@ var (
 	testDir          string
 	ospreyconfigFlag string
 	ospreyconfig     *TestConfig
+	caDataConfigFlag string
+	caDataConfig     *TestConfig
 )
 
 var _ = BeforeSuite(func() {
@@ -56,6 +58,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).To(BeNil(), "Creates the osprey config")
 
 	ospreyconfigFlag = "--ospreyconfig=" + ospreyconfig.ConfigFile
+
+	caDataConfig, err = BuildCADataConfig(testDir, ospreys)
+	Expect(err).To(BeNil(), "Creates the osprey config")
+
+	caDataConfigFlag = "--ospreyconfig=" + caDataConfig.ConfigFile
 })
 
 var _ = AfterSuite(func() {
@@ -71,11 +78,12 @@ var _ = AfterSuite(func() {
 
 var _ = Describe("E2E", func() {
 	Context("user", func() {
-		var user, login, logout *clitest.CommandWrapper
+		var user, login, caDataLogin, logout *clitest.CommandWrapper
 
 		BeforeEach(func() {
 			user = Client("user", ospreyconfigFlag)
 			login = Client("user", "login", ospreyconfigFlag)
+			caDataLogin = Client("user", "login", caDataConfigFlag)
 			logout = Client("user", "logout", ospreyconfigFlag)
 		})
 
@@ -165,6 +173,10 @@ var _ = Describe("E2E", func() {
 		Context("login", func() {
 			It("logins successfully with good credentials", func() {
 				login.LoginAndAssertSuccess("jane", "foo")
+			})
+
+			It("logins successfully with good credentials and base64 CA data", func() {
+				caDataLogin.LoginAndAssertSuccess("jane", "foo")
 			})
 
 			It("fails login with invalid credentials", func() {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -186,38 +186,22 @@ var _ = Describe("E2E", func() {
 				}
 			})
 
-			Context("with certificate-authority-data", func() {
-				var caDataLogin *clitest.CommandWrapper
+			It("logs in with certificate-authority-data", func() {
+				caDataConfig, err := BuildCADataConfig(testDir, ospreys, true, "")
+				Expect(err).To(BeNil(), "Creates the osprey config")
+				caDataConfigFlag := "--ospreyconfig=" + caDataConfig.ConfigFile
+				caDataLogin := Client("user", "login", caDataConfigFlag)
 
-				BeforeEach(func() {
-					caDataConfig, err := BuildCADataConfig(testDir, ospreys, true, "")
-					Expect(err).To(BeNil(), "Creates the osprey config")
-
-					caDataConfigFlag := "--ospreyconfig=" + caDataConfig.ConfigFile
-
-					caDataLogin = Client("user", "login", caDataConfigFlag)
-				})
-
-				It("logs in successfully", func() {
-					caDataLogin.LoginAndAssertSuccess("jane", "foo")
-				})
+				caDataLogin.LoginAndAssertSuccess("jane", "foo")
 			})
 
-			Context("with CA and CA-data", func() {
-				var caDataLogin *clitest.CommandWrapper
+			It("logs in overriding certificate-authority with certificate-authority-data", func() {
+				caDataConfig, err := BuildCADataConfig(testDir, ospreys, true, "/road/to/nowhere")
+				Expect(err).To(BeNil(), "Creates the osprey config")
+				caDataConfigFlag := "--ospreyconfig=" + caDataConfig.ConfigFile
+				caDataLogin := Client("user", "login", caDataConfigFlag)
 
-				BeforeEach(func() {
-					caDataConfig, err := BuildCADataConfig(testDir, ospreys, true, "/road/to/nowhere")
-					Expect(err).To(BeNil(), "Creates the osprey config")
-
-					caDataConfigFlag := "--ospreyconfig=" + caDataConfig.ConfigFile
-
-					caDataLogin = Client("user", "login", caDataConfigFlag)
-				})
-
-				It("ignores CA path and logs in successfully", func() {
-					caDataLogin.LoginAndAssertSuccess("jane", "foo")
-				})
+				caDataLogin.LoginAndAssertSuccess("jane", "foo")
 			})
 
 			Context("kubeconfig file", func() {

--- a/e2e/ospreytest/fixtures.go
+++ b/e2e/ospreytest/fixtures.go
@@ -90,7 +90,8 @@ func (o *TestOsprey) ToGroupClaims(authInfo *clientgo.AuthInfo) ([]string, error
 func (o *TestOsprey) CallHealthcheck() (*http.Response, error) {
 	ospreyHealthCheckURL := fmt.Sprintf("%s/healthz", o.URL)
 	req, err := http.NewRequest(http.MethodGet, ospreyHealthCheckURL, nil)
-	httpClient, err := web.NewTLSClient(o.CertFile)
+	certData, _ := web.LoadTLSCert(o.CertFile)
+	httpClient, err := web.NewTLSClient(certData)
 
 	resp, err := httpClient.Do(req)
 	return resp, err

--- a/e2e/ospreytest/server.go
+++ b/e2e/ospreytest/server.go
@@ -1,14 +1,13 @@
 package ospreytest
 
 import (
-	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os/exec"
 	"path/filepath"
 
 	"github.com/onsi/ginkgo"
 	ospreyClient "github.com/sky-uk/osprey/client"
+	"github.com/sky-uk/osprey/common/web"
 	"github.com/sky-uk/osprey/e2e/clitest"
 	"github.com/sky-uk/osprey/e2e/dextest"
 	"github.com/sky-uk/osprey/e2e/ssltest"
@@ -111,45 +110,42 @@ func StopOsprey(server *TestOsprey) error {
 // BuildConfig creates an ospreyconfig file with as many targets as servers are provided.
 // It uses testDir as the home for the .kube and .osprey folders.
 func BuildConfig(testDir string, servers []*TestOsprey) (*TestConfig, error) {
-	config := ospreyClient.NewConfig()
-	config.Kubeconfig = fmt.Sprintf("%s/.kube/config", testDir)
-	for _, osprey := range servers {
-		targetName := osprey.OspreyconfigTargetName()
-		target := &ospreyClient.Osprey{
-			Server:               osprey.URL,
-			CertificateAuthority: osprey.CertFile,
-			Aliases:              []string{osprey.OspreyconfigAliasName()},
-		}
-		config.Targets[targetName] = target
-	}
-	ospreyconfigFile := fmt.Sprintf("%s/.osprey/config", testDir)
-	testConfig := &TestConfig{Config: config, ConfigFile: ospreyconfigFile}
-	return testConfig, ospreyClient.SaveConfig(config, ospreyconfigFile)
+	return BuildCADataConfig(testDir, servers, false, "")
 }
 
 // BuildCADataConfig creates an ospreyconfig file with as many targets as servers are provided.
 // It uses testDir as the home for the .kube and .osprey folders.
 // It also base64 encodes the CA data instead of using the file path.
-func BuildCADataConfig(testDir string, servers []*TestOsprey) (*TestConfig, error) {
+func BuildCADataConfig(testDir string, servers []*TestOsprey, caData bool, caPath string) (*TestConfig, error) {
 	config := ospreyClient.NewConfig()
 	config.Kubeconfig = fmt.Sprintf("%s/.kube/config", testDir)
+	ospreyconfigFile := fmt.Sprintf("%s/.osprey/config", testDir)
+
 	for _, osprey := range servers {
 		targetName := osprey.OspreyconfigTargetName()
-		certFile, err := ioutil.ReadFile(osprey.CertFile)
-		if err != nil {
-			return nil, err
+
+		target := &ospreyClient.Osprey{
+			Server:  osprey.URL,
+			Aliases: []string{osprey.OspreyconfigAliasName()},
 		}
 
-		caData := base64.StdEncoding.EncodeToString(certFile)
-		target := &ospreyClient.Osprey{
-			Server:                   osprey.URL,
-			CertificateAuthority:     "",
-			CertificateAuthorityData: caData,
-			Aliases:                  []string{osprey.OspreyconfigAliasName()},
+		if caData {
+			config.Kubeconfig = fmt.Sprintf("%s/.kube/config-data", testDir)
+			ospreyconfigFile = fmt.Sprintf("%s/.osprey/config-data", testDir)
+
+			certData, err := web.LoadTLSCert(osprey.CertFile)
+			if err != nil {
+				return nil, err
+			}
+
+			target.CertificateAuthority = caPath
+			target.CertificateAuthorityData = certData
+		} else {
+			target.CertificateAuthority = osprey.CertFile
 		}
+
 		config.Targets[targetName] = target
 	}
-	ospreyconfigFile := fmt.Sprintf("%s/.osprey/config", testDir)
 	testConfig := &TestConfig{Config: config, ConfigFile: ospreyconfigFile}
 	return testConfig, ospreyClient.SaveConfig(config, ospreyconfigFile)
 }

--- a/e2e/ospreytest/server.go
+++ b/e2e/ospreytest/server.go
@@ -130,7 +130,6 @@ func BuildCADataConfig(testDir string, servers []*TestOsprey, caData bool, caPat
 		}
 
 		if caData {
-			config.Kubeconfig = fmt.Sprintf("%s/.kube/config-data", testDir)
 			ospreyconfigFile = fmt.Sprintf("%s/.osprey/config-data", testDir)
 
 			certData, err := web.LoadTLSCert(osprey.CertFile)


### PR DESCRIPTION
This allows a user to paste in base64-encoded CA certificates, similar to kubeconfig files. With this enhancement, users can freely share their Osprey config files within their organization without worrying about file paths that can change between machines.