### PR TITLE
Preserve context config on user login

### DIFF
--- a/client/kubeconfig/config.go
+++ b/client/kubeconfig/config.go
@@ -83,6 +83,9 @@ func UpdateConfig(name string, aliases []string, tokenData *TokenInfo) error {
 	contexts := append(aliases, name)
 	for _, alias := range contexts {
 		context := clientgo.NewContext()
+		if oldContext, ok := config.Contexts[alias]; ok {
+			oldContext.DeepCopyInto(context)
+		}
 		context.Cluster = name
 		context.AuthInfo = name
 		config.Contexts[alias] = context


### PR DESCRIPTION
Prevents osprey from erasing context config
e.g. default namespace
#17 