### PR TITLE
List target only once if in multiple groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Release 1.3.0
+- Fixes displaying a target multiple times if the targets existed in
+  multiple groups.
+
 # Release 1.2.0
 - Handles `groups` for targets, allowing client commands to target a
   specific group.
@@ -5,6 +9,7 @@
 - All actions and outputs are now done against targets in alphabetical
   order.
 - Adds osprey `--version` flag to provide build information.
+- Keep custom context information after login. ([#17](https://github.com/sky-uk/osprey/issues/17))
 
 # Release 1.1.0
 - Adds support for `certificate-authority-data` in client config.

--- a/client/config_snapshot.go
+++ b/client/config_snapshot.go
@@ -142,8 +142,14 @@ func (t *ConfigSnapshot) GetGroup(name string) (Group, bool) {
 // Targets returns all the targets in the configuration in alphabetical order.
 func (t *ConfigSnapshot) Targets() []Target {
 	var targets []Target
+	set := make(map[string]*interface{})
 	for _, group := range t.groupsByName {
-		targets = append(targets, group.targets...)
+		for _, target := range group.targets {
+			if _, ok := set[target.name]; !ok {
+				set[target.name] = nil
+				targets = append(targets, target)
+			}
+		}
 	}
 	return sortTargets(targets)
 }

--- a/e2e/targets_test.go
+++ b/e2e/targets_test.go
@@ -1,13 +1,13 @@
 package e2e
 
 import (
-	"strings"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/sky-uk/osprey/e2e/ospreytest"
 
 	"fmt"
+
+	"strings"
 
 	"github.com/sky-uk/osprey/e2e/clitest"
 )
@@ -53,12 +53,7 @@ var _ = Describe("Targets", func() {
 			It("displays the targets in alphabetical order", func() {
 				targets.RunAndAssertSuccess()
 
-				trimmedOutput := strings.Trim(targets.GetOutput(), "\n")
-				outputLines := strings.Split(trimmedOutput, "\n")
-				Expect(len(outputLines)).To(BeNumerically(">", 0))
-				for i, expectedLine := range expectedOutputLines {
-					Expect(outputLines[i]).To(Equal(expectedLine))
-				}
+				Expect(targets.GetOutput()).To(ContainSubstring(strings.Join(expectedOutputLines, "\n")))
 			})
 		}
 
@@ -69,6 +64,21 @@ var _ = Describe("Targets", func() {
 					fmt.Sprintf("* %s", OspreyTargetOutput("local")),
 					fmt.Sprintf("  %s", OspreyTargetOutput("prod")),
 					fmt.Sprintf("  %s", OspreyTargetOutput("sandbox")),
+					fmt.Sprintf("  %s", OspreyTargetOutput("stage")),
+				}
+			})
+
+			AssertTargetsSuccessfulOutput()
+		})
+
+		Context("with a target in multiple groups", func() {
+			BeforeEach(func() {
+				environmentsToUse = map[string][]string{
+					"dev":   {"development", "dev"},
+					"stage": {"development"},
+				}
+				expectedOutputLines = []string{"Osprey targets:",
+					fmt.Sprintf("  %s", OspreyTargetOutput("dev")),
 					fmt.Sprintf("  %s", OspreyTargetOutput("stage")),
 				}
 			})


### PR DESCRIPTION
Fixes `osprey config targets` displaying a target multiple times if the
target belongs to multiple groups.

Related to https://github.com/sky-uk/osprey/issues/9