### PR TITLE
Fix latest release publishing

### DIFF
--- a/.bintray.latest.template
+++ b/.bintray.latest.template
@@ -1,0 +1,24 @@
+{
+  "package": {
+    "name": "osprey",
+    "repo": "oss-generic",
+    "subject": "sky-uk",
+    "desc": "Osprey: Kubernetes CLI OIDC Authentication Client",
+    "vcs_url": "https://github.com/sky-uk/osprey",
+    "licenses": ["BSD 3-Clause"],
+    "labels": ["Osprey", "kubernetes", "oidc", "authentication", "client"]
+  },
+  "version": {
+    "name": "latest",
+    "released": "@release_date",
+    "vcs_tag": "@version"
+  },
+  "files":
+  [
+    { "includePattern": "dist/latest/(.*)/osprey\\.(.*)",
+      "uploadPattern": "osprey/latest/osprey-latest_$1.$2",
+      "matrixParams": { "override": 1 }
+    }
+  ],
+  "publish": @publish
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,13 @@ deploy:
   key: $BINTRAY_API_KEY
   on:
     tags: true
+- provider: bintray
+  skip_cleanup: true
+  file: dist/bintray.latest.json
+  user: $BINTRAY_USER
+  key: $BINTRAY_API_KEY
+  on:
+    condition: -e dist/bintray.latest.json
 - provider: script
   script: make release-docker
   skip_cleanup: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fix `latest` artifacts publishing
+
 # Release 1.3.0
 - Fixes displaying a target multiple times if the targets existed in
   multiple groups.

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ else
 				;; \
 		esac ;\
 		if [ "$(git_rev)" = "$(latest_git_rev)" ]; then \
+			sed 's/@version/$(git_tag)/g; s/@release_date/$(release_date)/g; s/@publish/$(BINTRAY_PUBLISH)/g' .bintray.latest.template > $(dist_dir)/bintray.latest.json
 			echo "updating latest distribution"; \
 			latest=$(dist_dir)/latest/$$distribution; \
 			mkdir -p $$latest; \


### PR DESCRIPTION
Treat `latest` as a version in bintray, and deploy the current version
and the latest version artifacts separately.

The bintray deploy task originally created included the latest artifacts
as part of the bintray deploy for a specific version.
Because of this, subsequent releases failed to update the artifacts, as
they were tied to a specific version, e.g.
```
Bintray Upload] Bintray response: 409 Conflict. Unable to upload files:
An artifact with the path '[...]' already exists under another version.
```