### PR TITLE
Log in with cli supplied creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ $ osprey user login
 user: someone
 password: ***
 Logged in to local.cluster
+
+# Alternatively, you may provide username and password as CLI arguments
+$ osprey user login someone $MY_PASSWORD
+Logged in to local.cluster
 ```
 
 It will generate the kubeconfig file creating a `cluster` and `user` entry

--- a/client/credentials.go
+++ b/client/credentials.go
@@ -19,7 +19,10 @@ type LoginCredentials struct {
 }
 
 // GetCredentials loads the credentials from the terminal or stdin.
-func GetCredentials() (*LoginCredentials, error) {
+func GetCredentials(args []string) (*LoginCredentials, error) {
+	if len(args) == 2 {
+		return &LoginCredentials{Username: strings.TrimSpace(args[0]), Password: strings.TrimSpace(args[1])}, nil
+	}
 	if terminal.IsTerminal(int(syscall.Stdin)) {
 		return consumeCredentials(hiddenInput)
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -33,7 +33,7 @@ func init() {
 	userCmd.AddCommand(loginCmd)
 }
 
-func login(_ *cobra.Command, _ []string) {
+func login(_ *cobra.Command, args []string) {
 	ospreyconfig, err := client.LoadConfig(ospreyconfigFile)
 	if err != nil {
 		log.Fatalf("Failed to load ospreyconfig file %s: %v", ospreyconfigFile, err)
@@ -52,7 +52,7 @@ func login(_ *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	credentials, err := client.GetCredentials()
+	credentials, err := client.GetCredentials(args)
 	if err != nil {
 		log.Fatalf("Failed to get credentials: %v", err)
 	}


### PR DESCRIPTION
Hey all, I believe the following

```shell
$ osprey user login username password
```
is useful for automation scripts. Since supplying username/password as `echo "username\npassword | osprey user login` doesn't work because it reads two values one by one, I thought this PR might be helpful.


Thanks!