### PR TITLE
Fix prepare-release-bintray make target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
+
 # Release 1.4.0
 - Update Alpine to 3.9 - fix vulnerability https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5021.
 - Update golint dependency to golang.org/x/lint/golint.
 - Update error message during login.
 - Fix broken functionally to allow osprey server to start without TLS.
 - Fix `latest` artifacts publishing.
+- Fix `prepare-release-bintray` make target.
 
 # Release 1.3.0
 - Fixes displaying a target multiple times if the targets existed in

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ else
 				;; \
 		esac ;\
 		if [ "$(git_rev)" = "$(latest_git_rev)" ]; then \
-			sed 's/@version/$(git_tag)/g; s/@release_date/$(release_date)/g; s/@publish/$(BINTRAY_PUBLISH)/g' .bintray.latest.template > $(dist_dir)/bintray.latest.json
+			sed 's/@version/$(git_tag)/g; s/@release_date/$(release_date)/g; s/@publish/$(BINTRAY_PUBLISH)/g' .bintray.latest.template > $(dist_dir)/bintray.latest.json \
 			echo "updating latest distribution"; \
 			latest=$(dist_dir)/latest/$$distribution; \
 			mkdir -p $$latest; \


### PR DESCRIPTION
It was missing a `\` in one of the shell lines