### PR TITLE
Close the browser window automatically after login

### DIFF
--- a/client/oidc/oidc.go
+++ b/client/oidc/oidc.go
@@ -138,7 +138,7 @@ func (c *Client) handleRedirectURI(ctx context.Context) http.HandlerFunc {
 function closeWindow() {
   open(location, '_self').close();
 }
-window.onload = setTimeout(closeWindow, 800);
+window.onload = setTimeout(closeWindow, 1000);
 </script>
 </head>
 <body>

--- a/client/oidc/oidc.go
+++ b/client/oidc/oidc.go
@@ -131,7 +131,20 @@ func (c *Client) handleRedirectURI(ctx context.Context) http.HandlerFunc {
 
 		c.authenticated = true
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("<html><head></head><body><h1 style='font-family: 'Source Code Pro''>Successfully logged in</h1></body></html>"))
+		w.Write([]byte(`<html>
+<head>
+<title>Osprey Logged In</title>
+<script type="text/javascript">
+function closeWindow() {
+  open(location, '_self').close();
+}
+window.onload = setTimeout(closeWindow, 800);
+</script>
+</head>
+<body>
+<h1>Successfully logged in...</h1>
+</body>
+</html>`))
 
 		c.stopChan <- tokenResponse{
 			oauth2Token,


### PR DESCRIPTION
This is a small convenience to remove the need to manually close the login window.

800ms chosen scientifically as not too slow and not too fast.

This is a follow up to https://github.com/sky-uk/osprey/pull/52.