### PR TITLE
Use window.close() so it doesn't make Firefox unhappy

### DIFF
--- a/client/oidc/oidc.go
+++ b/client/oidc/oidc.go
@@ -136,7 +136,7 @@ func (c *Client) handleRedirectURI(ctx context.Context) http.HandlerFunc {
 <title>Osprey Logged In</title>
 <script type="text/javascript">
 function closeWindow() {
-  open(location, '_self').close();
+  window.close();
 }
 window.onload = setTimeout(closeWindow, 1000);
 </script>


### PR DESCRIPTION
window.close() seems to work okay on Chrome for refreshing a session.