### PR TITLE
Allow osprey client to read CA cert directly from API server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Release 2.5.0
+- Add ability for osprey client to fetch the API server CA from the API server itself,
+  rather than needing an osprey server deployment to serve it. See the Kubernetes feature
+  gate RootCAConfigMap introduced in v1.13, which became enabled by default in 1.20.
+
 # Release 2.4.0
 - Add username/password command line options for Osprey login
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ on your behalf.
 
 ## Installation
 
-Osprey is currently supported in linux, mac OS and windows and it can be
+Osprey is currently supported in linux, macOS and windows and it can be
 installed as a standalone executable, or it can be run as a container (only
 linux).
 The docker container is aimed to be used for the server side, while the
@@ -46,7 +46,7 @@ Osprey's executable binaries can be downloaded from our [Bintray repository](htt
 To install a specific version replace `<version>` with the release version
 (e.g `v9.9.0`; mind the `v` prefix).
 
-**Linux and Mac OS**
+**Linux and macOS**
 ```
   curl -fsSL https://dl.bintray.com/sky-uk/oss-generic/osprey/<version>/osprey-<version>_linux_amd64.tar.gz -o osprey.tar.gz
 
@@ -56,7 +56,7 @@ To install a specific version replace `<version>` with the release version
 `$HOME/.local/bin` should be in your `$PATH`, or replace it with one that
 better suits your setup.
 
-To install for Mac OS replace `linux` for `darwin`
+To install for macOS replace `linux` for `darwin`
 
 **Windows**
 ```
@@ -241,7 +241,7 @@ The client installation script gets the configuration supported by the
 installed version.
 
 The client uses a yaml configuration file. It's recommended location is:
-`$HOME/.osprey/config`. Its contents are as follow:
+`$HOME/.osprey/config`. Its contents are as follows:
 ```
 # Optional path to the kubeconfig file to load/update when loging in.
 # Uses kubectl defaults if absent ($HOME/.kube/config).
@@ -306,6 +306,11 @@ providers:
     targets:
       foo.cluster:
         server: http://osprey.foo.cluster
+        # If api-server is specified, osprey will fetch the CA cert from the API server itself. Overrides "server".
+        # A ConfigMap in kube-publiuc called kube-root-ca.crt should be made accessible to system:anonymous
+        # This ConfigMap is created automatically with the Kubernetes feature gate RootCAConfigMap which was
+        # alpha in Kubernetes v1.13 and became enabled by default in v1.20+
+        # api-server: http://apiserver.foo.cluster
         aliases: [foo.alias]
         groups: [foo]
 
@@ -383,6 +388,8 @@ In this mode, the required flags are:
 is the default location of the CA when running inside a kubernetes cluster.
 - `apiServerURL`, the api-server URL to return to the osprey client
 
+Note that since v2.5.0 osprey client can fetch the CA cert directly from the API server without needing a
+deployment of osprey server.
 
 ### `osprey serve auth`
 Starts an instance of the osprey server that will listen for authentication

--- a/client/azure.go
+++ b/client/azure.go
@@ -142,7 +142,7 @@ func (r *azureRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*Ta
 	}
 
 	var client = &http.Client{}
-	client, err := web.NewTLSClient(target.CertificateAuthorityData())
+	client, err := web.NewTLSClient(false, target.CertificateAuthorityData())
 	if err != nil {
 		return nil, fmt.Errorf("unable to create TLS client: %v", err)
 	}

--- a/client/azure.go
+++ b/client/azure.go
@@ -29,13 +29,14 @@ type AzureConfig struct {
 	ClientID string `yaml:"client-id,omitempty"`
 	// ClientSecret is the oidc client secret used for osprey
 	ClientSecret string `yaml:"client-secret,omitempty"`
-	// RedirectURI is the redirect URI that the oidc application is configured to call back to
+	// CertificateAuthority is the filesystem path from which to read the CA certificate
 	CertificateAuthority string `yaml:"certificate-authority,omitempty"`
 	// CertificateAuthorityData is base64-encoded CA cert data.
 	// This will override any cert file specified in CertificateAuthority.
 	// +optional
 	CertificateAuthorityData string `yaml:"certificate-authority-data,omitempty"`
-	RedirectURI              string `yaml:"redirect-uri,omitempty"`
+	// RedirectURI is the redirect URI that the oidc application is configured to call back to
+	RedirectURI string `yaml:"redirect-uri,omitempty"`
 	// Scopes is the list of scopes to request when performing the oidc login request
 	Scopes []string `yaml:"scopes"`
 	// AzureTenantID is the Azure Tenant ID assigned to your organisation

--- a/client/azure.go
+++ b/client/azure.go
@@ -87,7 +87,7 @@ func NewAzureRetriever(provider *AzureConfig, options RetrieverOptions) (Retriev
 
 	oidcEndpoint, err := oidc.GetWellKnownConfig(provider.IssuerURL)
 	if err != nil {
-		return nil, fmt.Errorf("unable to query well-known oidc config: %v", err)
+		return nil, fmt.Errorf("unable to query well-known oidc config: %w", err)
 	}
 	config.Endpoint = *oidcEndpoint
 	retriever := &azureRetriever{
@@ -114,7 +114,7 @@ type azureRetriever struct {
 func (r *azureRetriever) RetrieveUserDetails(target Target, authInfo api.AuthInfo) (*UserInfo, error) {
 	jwt, err := jws.ParseJWT([]byte(authInfo.Token))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse user token for %s: %v", target.Name(), err)
+		return nil, fmt.Errorf("failed to parse user token for %s: %w", target.Name(), err)
 	}
 
 	if jwt.Claims().Get("unique_name") != nil {
@@ -149,15 +149,15 @@ func (r *azureRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*Ta
 	if target.ShouldFetchCAFromAPIServer() {
 		tlsClient, err := web.NewTLSClient()
 		if err != nil {
-			return nil, fmt.Errorf("unable to create TLS client: %v", err)
+			return nil, fmt.Errorf("unable to create TLS client: %w", err)
 		}
 		req, err := createCAConfigMapRequest(target.APIServer())
 		if err != nil {
-			return nil, fmt.Errorf("unable to create API Server request for CA ConfigMap: %v", err)
+			return nil, fmt.Errorf("unable to create API Server request for CA ConfigMap: %w", err)
 		}
 		resp, err := tlsClient.Do(req)
 		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve CA from API Server endpoint: %v", err)
+			return nil, fmt.Errorf("failed to retrieve CA from API Server endpoint: %w", err)
 		}
 		caConfigMap, err := r.consumeCAConfigMapResponse(resp)
 		if err != nil {
@@ -169,16 +169,16 @@ func (r *azureRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*Ta
 	} else {
 		tlsClient, err := web.NewTLSClient(target.CertificateAuthorityData())
 		if err != nil {
-			return nil, fmt.Errorf("unable to create TLS client: %v", err)
+			return nil, fmt.Errorf("unable to create TLS client: %w", err)
 		}
 
 		req, err := createClusterInfoRequest(target.Server())
 		if err != nil {
-			return nil, fmt.Errorf("unable to create cluster-info request: %v", err)
+			return nil, fmt.Errorf("unable to create cluster-info request: %w", err)
 		}
 		resp, err := tlsClient.Do(req)
 		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve cluster-info: %v", err)
+			return nil, fmt.Errorf("failed to retrieve cluster-info: %w", err)
 		}
 		clusterInfo, err := pb.ConsumeClusterInfoResponse(resp)
 		if err != nil {
@@ -206,13 +206,13 @@ func (r *azureRetriever) consumeCAConfigMapResponse(response *http.Response) (*c
 	if response.StatusCode == http.StatusOK {
 		data, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read CA response from API Server: %v", err)
+			return nil, fmt.Errorf("failed to read CA response from API Server: %w", err)
 		}
 		defer response.Body.Close()
 		var configMap = &configMap{}
 		err = json.Unmarshal(data, configMap)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse response: %v", err)
+			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		return configMap, nil
 	}

--- a/client/azure.go
+++ b/client/azure.go
@@ -147,7 +147,7 @@ func (r *azureRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*Ta
 	var apiServerURL, apiServerCA string
 
 	if target.ShouldFetchCAFromAPIServer() {
-		tlsClient, err := web.NewTLSClient(true)
+		tlsClient, err := web.NewTLSClient()
 		if err != nil {
 			return nil, fmt.Errorf("unable to create TLS client: %v", err)
 		}
@@ -167,7 +167,7 @@ func (r *azureRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*Ta
 		apiServerCA = base64.StdEncoding.EncodeToString([]byte(caConfigMap.Data.CACertData))
 
 	} else {
-		tlsClient, err := web.NewTLSClient(false, target.CertificateAuthorityData())
+		tlsClient, err := web.NewTLSClient(target.CertificateAuthorityData())
 		if err != nil {
 			return nil, fmt.Errorf("unable to create TLS client: %v", err)
 		}

--- a/client/azure.go
+++ b/client/azure.go
@@ -203,14 +203,15 @@ type configMapData struct {
 }
 
 func (r *azureRetriever) consumeCAConfigMapResponse(response *http.Response) (*configMap, error) {
-	data, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading CA response from API Server: %w", err)
-	}
-	defer response.Body.Close()
 	if response.StatusCode == http.StatusOK {
+		data, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading CA response from API Server: %w", err)
+		}
+		defer response.Body.Close()
+
 		var configMap = &configMap{}
-		err := json.Unmarshal(data, configMap)
+		err = json.Unmarshal(data, configMap)
 		if err != nil {
 			return nil, fmt.Errorf("parsing CA response from API Server: %w", err)
 		}

--- a/client/config.go
+++ b/client/config.go
@@ -62,12 +62,12 @@ func NewConfig() *Config {
 func LoadConfig(path string) (*Config, error) {
 	in, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading config file %s: %w", path, err)
+		return nil, fmt.Errorf("failed to read config file %s: %v", path, err)
 	}
 	config := &Config{}
 	err = yaml.Unmarshal(in, config)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshalling config file %s: %w", path, err)
+		return nil, fmt.Errorf("failed to unmarshal config file %s: %v", path, err)
 	}
 
 	if config.Providers.Azure != nil {
@@ -87,11 +87,11 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("invalid config %s: %w", path, err)
+		return nil, fmt.Errorf("invalid config %s: %v", path, err)
 	}
 	err = config.validateGroups()
 	if err != nil {
-		return nil, fmt.Errorf("invalid groups: %w", err)
+		return nil, fmt.Errorf("invalid groups: %v", err)
 	}
 	return config, err
 }
@@ -100,15 +100,15 @@ func LoadConfig(path string) (*Config, error) {
 func SaveConfig(config *Config, path string) error {
 	err := os.MkdirAll(filepath.Dir(path), 0755)
 	if err != nil {
-		return fmt.Errorf("accessing config dir %s: %w", path, err)
+		return fmt.Errorf("failed to access config dir %s: %v", path, err)
 	}
 	out, err := yaml.Marshal(config)
 	if err != nil {
-		return fmt.Errorf("marshalling config file %s: %w", path, err)
+		return fmt.Errorf("failed to marshal config file %s: %v", path, err)
 	}
 	err = ioutil.WriteFile(path, out, 0755)
 	if err != nil {
-		return fmt.Errorf("writing config file %s: %w", path, err)
+		return fmt.Errorf("failed to write config file %s: %v", path, err)
 	}
 	return nil
 }
@@ -169,7 +169,7 @@ func setTargetCA(certificateAuthority, certificateAuthorityData string, targets 
 	if ospreyCertData == "" && certificateAuthority != "" {
 		ospreyCertData, err = web.LoadTLSCert(certificateAuthority)
 		if err != nil {
-			return fmt.Errorf("loading global CA certificate: %w", err)
+			return fmt.Errorf("failed to load global CA certificate: %v", err)
 		}
 	}
 
@@ -181,7 +181,7 @@ func setTargetCA(certificateAuthority, certificateAuthorityData string, targets 
 		} else if target.CertificateAuthority != "" && target.CertificateAuthorityData == "" {
 			certData, err := web.LoadTLSCert(target.CertificateAuthority)
 			if err != nil {
-				return fmt.Errorf("loading global CA certificate for target %s: %w", name, err)
+				return fmt.Errorf("failed to load global CA certificate for target %s: %v", name, err)
 			}
 			target.CertificateAuthorityData = certData
 		} else if target.CertificateAuthorityData != "" {

--- a/client/config.go
+++ b/client/config.go
@@ -62,12 +62,12 @@ func NewConfig() *Config {
 func LoadConfig(path string) (*Config, error) {
 	in, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read config file %s: %v", path, err)
+		return nil, fmt.Errorf("failed to read config file %s: %w", path, err)
 	}
 	config := &Config{}
 	err = yaml.Unmarshal(in, config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config file %s: %v", path, err)
+		return nil, fmt.Errorf("failed to unmarshal config file %s: %w", path, err)
 	}
 
 	if config.Providers.Azure != nil {
@@ -87,11 +87,11 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("invalid config %s: %v", path, err)
+		return nil, fmt.Errorf("invalid config %s: %w", path, err)
 	}
 	err = config.validateGroups()
 	if err != nil {
-		return nil, fmt.Errorf("invalid groups: %v", err)
+		return nil, fmt.Errorf("invalid groups: %w", err)
 	}
 	return config, err
 }
@@ -100,15 +100,15 @@ func LoadConfig(path string) (*Config, error) {
 func SaveConfig(config *Config, path string) error {
 	err := os.MkdirAll(filepath.Dir(path), 0755)
 	if err != nil {
-		return fmt.Errorf("failed to access config dir %s: %v", path, err)
+		return fmt.Errorf("failed to access config dir %s: %w", path, err)
 	}
 	out, err := yaml.Marshal(config)
 	if err != nil {
-		return fmt.Errorf("failed to marshal config file %s: %v", path, err)
+		return fmt.Errorf("failed to marshal config file %s: %w", path, err)
 	}
 	err = ioutil.WriteFile(path, out, 0755)
 	if err != nil {
-		return fmt.Errorf("failed to write config file %s: %v", path, err)
+		return fmt.Errorf("failed to write config file %s: %w", path, err)
 	}
 	return nil
 }
@@ -169,7 +169,7 @@ func setTargetCA(certificateAuthority, certificateAuthorityData string, targets 
 	if ospreyCertData == "" && certificateAuthority != "" {
 		ospreyCertData, err = web.LoadTLSCert(certificateAuthority)
 		if err != nil {
-			return fmt.Errorf("failed to load global CA certificate: %v", err)
+			return fmt.Errorf("failed to load global CA certificate: %w", err)
 		}
 	}
 
@@ -181,7 +181,7 @@ func setTargetCA(certificateAuthority, certificateAuthorityData string, targets 
 		} else if target.CertificateAuthority != "" && target.CertificateAuthorityData == "" {
 			certData, err := web.LoadTLSCert(target.CertificateAuthority)
 			if err != nil {
-				return fmt.Errorf("failed to load global CA certificate for target %s: %v", name, err)
+				return fmt.Errorf("failed to load global CA certificate for target %s: %w", name, err)
 			}
 			target.CertificateAuthorityData = certData
 		} else if target.CertificateAuthorityData != "" {

--- a/client/config.go
+++ b/client/config.go
@@ -62,12 +62,12 @@ func NewConfig() *Config {
 func LoadConfig(path string) (*Config, error) {
 	in, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read config file %s: %v", path, err)
+		return nil, fmt.Errorf("reading config file %s: %w", path, err)
 	}
 	config := &Config{}
 	err = yaml.Unmarshal(in, config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config file %s: %v", path, err)
+		return nil, fmt.Errorf("unmarshalling config file %s: %w", path, err)
 	}
 
 	if config.Providers.Azure != nil {
@@ -87,11 +87,11 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("invalid config %s: %v", path, err)
+		return nil, fmt.Errorf("invalid config %s: %w", path, err)
 	}
 	err = config.validateGroups()
 	if err != nil {
-		return nil, fmt.Errorf("invalid groups: %v", err)
+		return nil, fmt.Errorf("invalid groups: %w", err)
 	}
 	return config, err
 }
@@ -100,15 +100,15 @@ func LoadConfig(path string) (*Config, error) {
 func SaveConfig(config *Config, path string) error {
 	err := os.MkdirAll(filepath.Dir(path), 0755)
 	if err != nil {
-		return fmt.Errorf("failed to access config dir %s: %v", path, err)
+		return fmt.Errorf("accessing config dir %s: %w", path, err)
 	}
 	out, err := yaml.Marshal(config)
 	if err != nil {
-		return fmt.Errorf("failed to marshal config file %s: %v", path, err)
+		return fmt.Errorf("marshalling config file %s: %w", path, err)
 	}
 	err = ioutil.WriteFile(path, out, 0755)
 	if err != nil {
-		return fmt.Errorf("failed to write config file %s: %v", path, err)
+		return fmt.Errorf("writing config file %s: %w", path, err)
 	}
 	return nil
 }
@@ -169,7 +169,7 @@ func setTargetCA(certificateAuthority, certificateAuthorityData string, targets 
 	if ospreyCertData == "" && certificateAuthority != "" {
 		ospreyCertData, err = web.LoadTLSCert(certificateAuthority)
 		if err != nil {
-			return fmt.Errorf("failed to load global CA certificate: %v", err)
+			return fmt.Errorf("loading global CA certificate: %w", err)
 		}
 	}
 
@@ -181,7 +181,7 @@ func setTargetCA(certificateAuthority, certificateAuthorityData string, targets 
 		} else if target.CertificateAuthority != "" && target.CertificateAuthorityData == "" {
 			certData, err := web.LoadTLSCert(target.CertificateAuthority)
 			if err != nil {
-				return fmt.Errorf("failed to load global CA certificate for target %s: %v", name, err)
+				return fmt.Errorf("loading global CA certificate for target %s: %w", name, err)
 			}
 			target.CertificateAuthorityData = certData
 		} else if target.CertificateAuthorityData != "" {

--- a/client/config.go
+++ b/client/config.go
@@ -33,7 +33,11 @@ type Providers struct {
 // TargetEntry contains information about how to communicate with an osprey server
 type TargetEntry struct {
 	// Server is the address of the osprey server (hostname:port).
+	// +optional
 	Server string `yaml:"server,omitempty"`
+	// APIServer is the address of the API server (hostname:port).
+	// +optional
+	APIServer string `yaml:"api-server,omitempty"`
 	// CertificateAuthority is the path to a cert file for the certificate authority.
 	// +optional
 	CertificateAuthority string `yaml:"certificate-authority,omitempty"`

--- a/client/credentials.go
+++ b/client/credentials.go
@@ -57,5 +57,5 @@ func hiddenInput(inputName string, reader *bufio.Reader) (string, error) {
 	if err == nil {
 		return strings.TrimSpace(string(passwordBytes)), nil
 	}
-	return "", fmt.Errorf("failed to read %s: %v", inputName, err)
+	return "", fmt.Errorf("failed to read %s: %w", inputName, err)
 }

--- a/client/credentials.go
+++ b/client/credentials.go
@@ -57,5 +57,5 @@ func hiddenInput(inputName string, reader *bufio.Reader) (string, error) {
 	if err == nil {
 		return strings.TrimSpace(string(passwordBytes)), nil
 	}
-	return "", fmt.Errorf("reading %s: %w", inputName, err)
+	return "", fmt.Errorf("failed to read %s: %v", inputName, err)
 }

--- a/client/credentials.go
+++ b/client/credentials.go
@@ -57,5 +57,5 @@ func hiddenInput(inputName string, reader *bufio.Reader) (string, error) {
 	if err == nil {
 		return strings.TrimSpace(string(passwordBytes)), nil
 	}
-	return "", fmt.Errorf("failed to read %s: %v", inputName, err)
+	return "", fmt.Errorf("reading %s: %w", inputName, err)
 }

--- a/client/kubeconfig/config.go
+++ b/client/kubeconfig/config.go
@@ -37,13 +37,13 @@ func LoadConfig(kubeconfigFile string) error {
 func UpdateConfig(name string, aliases []string, tokenData *client.TargetInfo) error {
 	config, err := GetConfig()
 	if err != nil {
-		return fmt.Errorf("failed to load existing kubeconfig at %s: %v", pathOptions.GetDefaultFilename(), err)
+		return fmt.Errorf("failed to load existing kubeconfig at %s: %w", pathOptions.GetDefaultFilename(), err)
 	}
 
 	cluster := clientgo.NewCluster()
 	cluster.CertificateAuthorityData, err = base64.StdEncoding.DecodeString(tokenData.ClusterCA)
 	if err != nil {
-		return fmt.Errorf("failed to decode certificate authority data: %v", err)
+		return fmt.Errorf("failed to decode certificate authority data: %w", err)
 	}
 
 	cluster.Server = tokenData.ClusterAPIServerURL
@@ -86,7 +86,7 @@ func UpdateConfig(name string, aliases []string, tokenData *client.TargetInfo) e
 func Remove(name string) error {
 	config, err := GetConfig()
 	if err != nil {
-		return fmt.Errorf("failed to load existing kubeconfig at %s: %v", pathOptions.GetDefaultFilename(), err)
+		return fmt.Errorf("failed to load existing kubeconfig at %s: %w", pathOptions.GetDefaultFilename(), err)
 	}
 	if config.AuthInfos[name] != nil {
 		if config.AuthInfos[name].Token != "" {
@@ -108,7 +108,7 @@ func GetConfig() (*clientgo.Config, error) {
 	}
 	config, err := pathOptions.GetStartingConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load kubeconfig from %s: %v", pathOptions.GetDefaultFilename(), err)
+		return nil, fmt.Errorf("failed to load kubeconfig from %s: %w", pathOptions.GetDefaultFilename(), err)
 	}
 	return config, nil
 }

--- a/client/kubeconfig/config.go
+++ b/client/kubeconfig/config.go
@@ -37,13 +37,13 @@ func LoadConfig(kubeconfigFile string) error {
 func UpdateConfig(name string, aliases []string, tokenData *client.TargetInfo) error {
 	config, err := GetConfig()
 	if err != nil {
-		return fmt.Errorf("failed to load existing kubeconfig at %s: %v", pathOptions.GetDefaultFilename(), err)
+		return fmt.Errorf("loading existing kubeconfig at %s: %w", pathOptions.GetDefaultFilename(), err)
 	}
 
 	cluster := clientgo.NewCluster()
 	cluster.CertificateAuthorityData, err = base64.StdEncoding.DecodeString(tokenData.ClusterCA)
 	if err != nil {
-		return fmt.Errorf("failed to decode certificate authority data: %v", err)
+		return fmt.Errorf("decoding certificate authority data: %w", err)
 	}
 
 	cluster.Server = tokenData.ClusterAPIServerURL
@@ -86,7 +86,7 @@ func UpdateConfig(name string, aliases []string, tokenData *client.TargetInfo) e
 func Remove(name string) error {
 	config, err := GetConfig()
 	if err != nil {
-		return fmt.Errorf("failed to load existing kubeconfig at %s: %v", pathOptions.GetDefaultFilename(), err)
+		return fmt.Errorf("loading existing kubeconfig at %s: %w", pathOptions.GetDefaultFilename(), err)
 	}
 	if config.AuthInfos[name] != nil {
 		if config.AuthInfos[name].Token != "" {
@@ -108,7 +108,7 @@ func GetConfig() (*clientgo.Config, error) {
 	}
 	config, err := pathOptions.GetStartingConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load kubeconfig from %s: %v", pathOptions.GetDefaultFilename(), err)
+		return nil, fmt.Errorf("loading kubeconfig from %s: %w", pathOptions.GetDefaultFilename(), err)
 	}
 	return config, nil
 }

--- a/client/kubeconfig/config.go
+++ b/client/kubeconfig/config.go
@@ -37,13 +37,13 @@ func LoadConfig(kubeconfigFile string) error {
 func UpdateConfig(name string, aliases []string, tokenData *client.TargetInfo) error {
 	config, err := GetConfig()
 	if err != nil {
-		return fmt.Errorf("loading existing kubeconfig at %s: %w", pathOptions.GetDefaultFilename(), err)
+		return fmt.Errorf("failed to load existing kubeconfig at %s: %v", pathOptions.GetDefaultFilename(), err)
 	}
 
 	cluster := clientgo.NewCluster()
 	cluster.CertificateAuthorityData, err = base64.StdEncoding.DecodeString(tokenData.ClusterCA)
 	if err != nil {
-		return fmt.Errorf("decoding certificate authority data: %w", err)
+		return fmt.Errorf("failed to decode certificate authority data: %v", err)
 	}
 
 	cluster.Server = tokenData.ClusterAPIServerURL
@@ -86,7 +86,7 @@ func UpdateConfig(name string, aliases []string, tokenData *client.TargetInfo) e
 func Remove(name string) error {
 	config, err := GetConfig()
 	if err != nil {
-		return fmt.Errorf("loading existing kubeconfig at %s: %w", pathOptions.GetDefaultFilename(), err)
+		return fmt.Errorf("failed to load existing kubeconfig at %s: %v", pathOptions.GetDefaultFilename(), err)
 	}
 	if config.AuthInfos[name] != nil {
 		if config.AuthInfos[name].Token != "" {
@@ -108,7 +108,7 @@ func GetConfig() (*clientgo.Config, error) {
 	}
 	config, err := pathOptions.GetStartingConfig()
 	if err != nil {
-		return nil, fmt.Errorf("loading kubeconfig from %s: %w", pathOptions.GetDefaultFilename(), err)
+		return nil, fmt.Errorf("failed to load kubeconfig from %s: %v", pathOptions.GetDefaultFilename(), err)
 	}
 	return config, nil
 }

--- a/client/oidc/device.go
+++ b/client/oidc/device.go
@@ -43,17 +43,17 @@ func (c *Client) AuthWithDeviceFlow(ctx context.Context, loginTimeout time.Durat
 
 	req, err := http.NewRequest(http.MethodPost, deviceAuthURL, strings.NewReader(urlParams.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("unable to create request: %v", err)
+		return nil, fmt.Errorf("unable to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	response, err := ctxhttp.Do(ctx, nil, req)
 	if err != nil {
-		return nil, fmt.Errorf("unable to post form to %s: %v", deviceAuthURL, err)
+		return nil, fmt.Errorf("unable to post form to %s: %w", deviceAuthURL, err)
 	}
 
 	body, err := ioutil.ReadAll(io.LimitReader(response.Body, 1<<20))
 	if err != nil {
-		return nil, fmt.Errorf("unable to read device-flow response: %v", err)
+		return nil, fmt.Errorf("unable to read device-flow response: %w", err)
 	}
 
 	if code := response.StatusCode; code < 200 || code > 299 {
@@ -62,7 +62,7 @@ func (c *Client) AuthWithDeviceFlow(ctx context.Context, loginTimeout time.Durat
 
 	deviceAuth := &DeviceFlowAuth{}
 	if err = json.Unmarshal(body, deviceAuth); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal device-flow response: %v", err)
+		return nil, fmt.Errorf("unable to unmarshal device-flow response: %w", err)
 	}
 
 	// Print the message that is obtained from the previous request. This contains the message and URL from the OIDC provider
@@ -81,7 +81,7 @@ func (c *Client) AuthWithDeviceFlow(ctx context.Context, loginTimeout time.Durat
 		return nil, fmt.Errorf("exceeded device-code login deadline")
 	case deviceCodePoll := <-ch:
 		if deviceCodePoll.error != nil {
-			return nil, fmt.Errorf("failed to fetch device-flow token: %v", err)
+			return nil, fmt.Errorf("failed to fetch device-flow token: %w", err)
 		}
 		c.authenticated = true
 		return deviceCodePoll.Token, nil

--- a/client/oidc/device.go
+++ b/client/oidc/device.go
@@ -43,26 +43,26 @@ func (c *Client) AuthWithDeviceFlow(ctx context.Context, loginTimeout time.Durat
 
 	req, err := http.NewRequest(http.MethodPost, deviceAuthURL, strings.NewReader(urlParams.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("unable to create request: %v", err)
+		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	response, err := ctxhttp.Do(ctx, nil, req)
 	if err != nil {
-		return nil, fmt.Errorf("unable to post form to %s: %v", deviceAuthURL, err)
+		return nil, fmt.Errorf("posting form to %s: %w", deviceAuthURL, err)
 	}
 
 	body, err := ioutil.ReadAll(io.LimitReader(response.Body, 1<<20))
 	if err != nil {
-		return nil, fmt.Errorf("unable to read device-flow response: %v", err)
+		return nil, fmt.Errorf("reading device-flow response: %w", err)
 	}
 
 	if code := response.StatusCode; code < 200 || code > 299 {
-		return nil, fmt.Errorf("HTTP error %d: %s", code, body)
+		return nil, fmt.Errorf("received HTTP %d: %s", code, body)
 	}
 
 	deviceAuth := &DeviceFlowAuth{}
 	if err = json.Unmarshal(body, deviceAuth); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal device-flow response: %v", err)
+		return nil, fmt.Errorf("unmarshalling device-flow response: %w", err)
 	}
 
 	// Print the message that is obtained from the previous request. This contains the message and URL from the OIDC provider
@@ -81,7 +81,7 @@ func (c *Client) AuthWithDeviceFlow(ctx context.Context, loginTimeout time.Durat
 		return nil, fmt.Errorf("exceeded device-code login deadline")
 	case deviceCodePoll := <-ch:
 		if deviceCodePoll.error != nil {
-			return nil, fmt.Errorf("failed to fetch device-flow token: %v", err)
+			return nil, fmt.Errorf("fetching device-flow token: %v", err)
 		}
 		c.authenticated = true
 		return deviceCodePoll.Token, nil

--- a/client/oidc/device.go
+++ b/client/oidc/device.go
@@ -43,26 +43,26 @@ func (c *Client) AuthWithDeviceFlow(ctx context.Context, loginTimeout time.Durat
 
 	req, err := http.NewRequest(http.MethodPost, deviceAuthURL, strings.NewReader(urlParams.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return nil, fmt.Errorf("unable to create request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	response, err := ctxhttp.Do(ctx, nil, req)
 	if err != nil {
-		return nil, fmt.Errorf("posting form to %s: %w", deviceAuthURL, err)
+		return nil, fmt.Errorf("unable to post form to %s: %v", deviceAuthURL, err)
 	}
 
 	body, err := ioutil.ReadAll(io.LimitReader(response.Body, 1<<20))
 	if err != nil {
-		return nil, fmt.Errorf("reading device-flow response: %w", err)
+		return nil, fmt.Errorf("unable to read device-flow response: %v", err)
 	}
 
 	if code := response.StatusCode; code < 200 || code > 299 {
-		return nil, fmt.Errorf("received HTTP %d: %s", code, body)
+		return nil, fmt.Errorf("HTTP error %d: %s", code, body)
 	}
 
 	deviceAuth := &DeviceFlowAuth{}
 	if err = json.Unmarshal(body, deviceAuth); err != nil {
-		return nil, fmt.Errorf("unmarshalling device-flow response: %w", err)
+		return nil, fmt.Errorf("unable to unmarshal device-flow response: %v", err)
 	}
 
 	// Print the message that is obtained from the previous request. This contains the message and URL from the OIDC provider
@@ -81,7 +81,7 @@ func (c *Client) AuthWithDeviceFlow(ctx context.Context, loginTimeout time.Durat
 		return nil, fmt.Errorf("exceeded device-code login deadline")
 	case deviceCodePoll := <-ch:
 		if deviceCodePoll.error != nil {
-			return nil, fmt.Errorf("fetching device-flow token: %v", err)
+			return nil, fmt.Errorf("failed to fetch device-flow token: %v", err)
 		}
 		c.authenticated = true
 		return deviceCodePoll.Token, nil

--- a/client/oidc/oidc.go
+++ b/client/oidc/oidc.go
@@ -46,7 +46,7 @@ type tokenResponse struct {
 func (c *Client) AuthWithOIDCCallback(ctx context.Context, loginTimeout time.Duration, disableBrowserPopup bool) (*oauth2.Token, error) {
 	redirectURL, err := url.Parse(c.oAuthConfig.RedirectURL)
 	if err != nil {
-		log.Fatalf("Unable to parse oidc redirect uri: %e", err)
+		log.Fatalf("pa OIDC redirect uri: %e", err)
 	}
 
 	authURL := c.oAuthConfig.AuthCodeURL(ospreyState)
@@ -95,7 +95,7 @@ func (c *Client) AuthWithOIDCCallback(ctx context.Context, loginTimeout time.Dur
 		_ = h.Shutdown(ctx)
 		return nil, fmt.Errorf("exceeded login deadline")
 	case err := <-ch:
-		return nil, fmt.Errorf("unable to start local call-back webserver %v", err)
+		return nil, fmt.Errorf("starting local call-back webserver %w", err)
 	case resp := <-c.stopChan:
 		_ = h.Shutdown(ctx)
 		if resp.responseError != nil {
@@ -120,7 +120,7 @@ func (c *Client) handleRedirectURI(ctx context.Context) http.HandlerFunc {
 
 		oauth2Token, err := c.doAuthRequest(ctx, r)
 		if err != nil {
-			err := fmt.Errorf("failed to exchange token: %v", err)
+			err := fmt.Errorf("exchanging token: %w", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			c.stopChan <- tokenResponse{
 				nil,

--- a/client/oidc/oidc.go
+++ b/client/oidc/oidc.go
@@ -95,7 +95,7 @@ func (c *Client) AuthWithOIDCCallback(ctx context.Context, loginTimeout time.Dur
 		_ = h.Shutdown(ctx)
 		return nil, fmt.Errorf("exceeded login deadline")
 	case err := <-ch:
-		return nil, fmt.Errorf("unable to start local call-back webserver %v", err)
+		return nil, fmt.Errorf("unable to start local call-back webserver %w", err)
 	case resp := <-c.stopChan:
 		_ = h.Shutdown(ctx)
 		if resp.responseError != nil {
@@ -120,7 +120,7 @@ func (c *Client) handleRedirectURI(ctx context.Context) http.HandlerFunc {
 
 		oauth2Token, err := c.doAuthRequest(ctx, r)
 		if err != nil {
-			err := fmt.Errorf("failed to exchange token: %v", err)
+			err := fmt.Errorf("failed to exchange token: %w", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			c.stopChan <- tokenResponse{
 				nil,

--- a/client/oidc/oidc.go
+++ b/client/oidc/oidc.go
@@ -46,7 +46,7 @@ type tokenResponse struct {
 func (c *Client) AuthWithOIDCCallback(ctx context.Context, loginTimeout time.Duration, disableBrowserPopup bool) (*oauth2.Token, error) {
 	redirectURL, err := url.Parse(c.oAuthConfig.RedirectURL)
 	if err != nil {
-		log.Fatalf("pa OIDC redirect uri: %e", err)
+		log.Fatalf("Unable to parse oidc redirect uri: %e", err)
 	}
 
 	authURL := c.oAuthConfig.AuthCodeURL(ospreyState)
@@ -95,7 +95,7 @@ func (c *Client) AuthWithOIDCCallback(ctx context.Context, loginTimeout time.Dur
 		_ = h.Shutdown(ctx)
 		return nil, fmt.Errorf("exceeded login deadline")
 	case err := <-ch:
-		return nil, fmt.Errorf("starting local call-back webserver %w", err)
+		return nil, fmt.Errorf("unable to start local call-back webserver %v", err)
 	case resp := <-c.stopChan:
 		_ = h.Shutdown(ctx)
 		if resp.responseError != nil {
@@ -120,7 +120,7 @@ func (c *Client) handleRedirectURI(ctx context.Context) http.HandlerFunc {
 
 		oauth2Token, err := c.doAuthRequest(ctx, r)
 		if err != nil {
-			err := fmt.Errorf("exchanging token: %w", err)
+			err := fmt.Errorf("failed to exchange token: %v", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			c.stopChan <- tokenResponse{
 				nil,

--- a/client/oidc/util.go
+++ b/client/oidc/util.go
@@ -30,24 +30,24 @@ func GetWellKnownConfig(issuerURL string) (*oauth2.Endpoint, error) {
 	wellknownConfig := &wellKnownConfiguration{}
 	_, err := url.Parse(issuerURL)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse issuer-url: %v", err)
+		return nil, fmt.Errorf("parsing issuer-url: %w", err)
 	}
 	client := http.DefaultClient
 	request, err := http.NewRequest(http.MethodGet, issuerURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create request: %v", err)
+		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("unable to make request: %v", err)
+		return nil, fmt.Errorf("making request: %w", err)
 	}
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch well-known configuration: %v", err)
+		return nil, fmt.Errorf("fetching well-known configuration: %w", err)
 	}
 	if err := json.Unmarshal(body, wellknownConfig); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal well-known configuration response: %v", err)
+		return nil, fmt.Errorf("unmarshalling well-known configuration response: %w", err)
 	}
 	return &oauth2.Endpoint{
 		AuthURL:  wellknownConfig.AuthEndpoint,

--- a/client/oidc/util.go
+++ b/client/oidc/util.go
@@ -30,24 +30,24 @@ func GetWellKnownConfig(issuerURL string) (*oauth2.Endpoint, error) {
 	wellknownConfig := &wellKnownConfiguration{}
 	_, err := url.Parse(issuerURL)
 	if err != nil {
-		return nil, fmt.Errorf("parsing issuer-url: %w", err)
+		return nil, fmt.Errorf("unable to parse issuer-url: %v", err)
 	}
 	client := http.DefaultClient
 	request, err := http.NewRequest(http.MethodGet, issuerURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return nil, fmt.Errorf("unable to create request: %v", err)
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("making request: %w", err)
+		return nil, fmt.Errorf("unable to make request: %v", err)
 	}
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("fetching well-known configuration: %w", err)
+		return nil, fmt.Errorf("unable to fetch well-known configuration: %v", err)
 	}
 	if err := json.Unmarshal(body, wellknownConfig); err != nil {
-		return nil, fmt.Errorf("unmarshalling well-known configuration response: %w", err)
+		return nil, fmt.Errorf("unable to unmarshal well-known configuration response: %v", err)
 	}
 	return &oauth2.Endpoint{
 		AuthURL:  wellknownConfig.AuthEndpoint,

--- a/client/oidc/util.go
+++ b/client/oidc/util.go
@@ -30,24 +30,24 @@ func GetWellKnownConfig(issuerURL string) (*oauth2.Endpoint, error) {
 	wellknownConfig := &wellKnownConfiguration{}
 	_, err := url.Parse(issuerURL)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse issuer-url: %v", err)
+		return nil, fmt.Errorf("unable to parse issuer-url: %w", err)
 	}
 	client := http.DefaultClient
 	request, err := http.NewRequest(http.MethodGet, issuerURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create request: %v", err)
+		return nil, fmt.Errorf("unable to create request: %w", err)
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("unable to make request: %v", err)
+		return nil, fmt.Errorf("unable to make request: %w", err)
 	}
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch well-known configuration: %v", err)
+		return nil, fmt.Errorf("unable to fetch well-known configuration: %w", err)
 	}
 	if err := json.Unmarshal(body, wellknownConfig); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal well-known configuration response: %v", err)
+		return nil, fmt.Errorf("unable to unmarshal well-known configuration response: %w", err)
 	}
 	return &oauth2.Endpoint{
 		AuthURL:  wellknownConfig.AuthEndpoint,

--- a/client/osprey.go
+++ b/client/osprey.go
@@ -80,7 +80,7 @@ func (r *ospreyRetriever) RetrieveUserDetails(target Target, authInfo api.AuthIn
 
 	jwt, err := jws.ParseJWT([]byte(idToken))
 	if err != nil {
-		return nil, fmt.Errorf("parsing user token for %s: %w", target.Name(), err)
+		return nil, fmt.Errorf("failed to parse user token for %s: %v", target.Name(), err)
 	}
 
 	user := jwt.Claims().Get("email")
@@ -113,11 +113,11 @@ func (r *ospreyRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*T
 
 	req, err := createAccessTokenRequest(target.Server(), r.credentials)
 	if err != nil {
-		return nil, fmt.Errorf("creating access-token request: %w", err)
+		return nil, fmt.Errorf("unable to create access-token request: %v", err)
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving access-token: %w", err)
+		return nil, fmt.Errorf("failed to retrieve access-token: %v", err)
 	}
 	defer resp.Body.Close()
 	accessToken, err := pb.ConsumeLoginResponse(resp)
@@ -149,7 +149,7 @@ func createAccessTokenRequest(host string, credentials *LoginCredentials) (*http
 	url := fmt.Sprintf("%s/access-token", host)
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating access-token request: %w", err)
+		return nil, fmt.Errorf("unable to create access-token request: %v", err)
 	}
 	authToken := basicAuth(credentials)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", authToken))
@@ -162,7 +162,7 @@ func createClusterInfoRequest(host string) (*http.Request, error) {
 	url := fmt.Sprintf("%s/cluster-info", host)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating cluster-info request: %w", err)
+		return nil, fmt.Errorf("unable to create cluster-info request: %v", err)
 	}
 	req.Header.Add("Accept", "application/octet-stream")
 
@@ -173,7 +173,7 @@ func createCAConfigMapRequest(host string) (*http.Request, error) {
 	url := fmt.Sprintf("%s/api/v1/namespaces/kube-public/configmaps/kube-root-ca.crt", host)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating CA ConfigMap request: %w", err)
+		return nil, fmt.Errorf("unable to create CA ConfigMap request: %v", err)
 	}
 	req.Header.Add("Accept", "application/json")
 

--- a/client/osprey.go
+++ b/client/osprey.go
@@ -80,7 +80,7 @@ func (r *ospreyRetriever) RetrieveUserDetails(target Target, authInfo api.AuthIn
 
 	jwt, err := jws.ParseJWT([]byte(idToken))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse user token for %s: %v", target.Name(), err)
+		return nil, fmt.Errorf("parsing user token for %s: %w", target.Name(), err)
 	}
 
 	user := jwt.Claims().Get("email")
@@ -113,11 +113,11 @@ func (r *ospreyRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*T
 
 	req, err := createAccessTokenRequest(target.Server(), r.credentials)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create access-token request: %v", err)
+		return nil, fmt.Errorf("creating access-token request: %w", err)
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve access-token: %v", err)
+		return nil, fmt.Errorf("retrieving access-token: %w", err)
 	}
 	defer resp.Body.Close()
 	accessToken, err := pb.ConsumeLoginResponse(resp)
@@ -149,7 +149,7 @@ func createAccessTokenRequest(host string, credentials *LoginCredentials) (*http
 	url := fmt.Sprintf("%s/access-token", host)
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create access-token request: %v", err)
+		return nil, fmt.Errorf("creating access-token request: %w", err)
 	}
 	authToken := basicAuth(credentials)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", authToken))
@@ -162,7 +162,7 @@ func createClusterInfoRequest(host string) (*http.Request, error) {
 	url := fmt.Sprintf("%s/cluster-info", host)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create cluster-info request: %v", err)
+		return nil, fmt.Errorf("creating cluster-info request: %w", err)
 	}
 	req.Header.Add("Accept", "application/octet-stream")
 
@@ -173,7 +173,7 @@ func createCAConfigMapRequest(host string) (*http.Request, error) {
 	url := fmt.Sprintf("%s/api/v1/namespaces/kube-public/configmaps/kube-root-ca.crt", host)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create CA ConfigMap request: %v", err)
+		return nil, fmt.Errorf("creating CA ConfigMap request: %w", err)
 	}
 	req.Header.Add("Accept", "application/json")
 

--- a/client/osprey.go
+++ b/client/osprey.go
@@ -99,7 +99,7 @@ func (r *ospreyRetriever) RetrieveUserDetails(target Target, authInfo api.AuthIn
 }
 
 func (r *ospreyRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*TargetInfo, error) {
-	httpClient, err := webClient.NewTLSClient(false, r.serverCertificateAuthorityData, target.CertificateAuthorityData())
+	httpClient, err := webClient.NewTLSClient(r.serverCertificateAuthorityData, target.CertificateAuthorityData())
 	if err != nil {
 		return nil, err
 	}

--- a/client/osprey.go
+++ b/client/osprey.go
@@ -96,7 +96,7 @@ func (r *ospreyRetriever) RetrieveUserDetails(target Target, authInfo api.AuthIn
 }
 
 func (r *ospreyRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*TargetInfo, error) {
-	httpClient, err := webClient.NewTLSClient(r.serverCertificateAuthorityData, target.CertificateAuthorityData())
+	httpClient, err := webClient.NewTLSClient(false, r.serverCertificateAuthorityData, target.CertificateAuthorityData())
 	if err != nil {
 		return nil, err
 	}

--- a/client/osprey.go
+++ b/client/osprey.go
@@ -80,7 +80,7 @@ func (r *ospreyRetriever) RetrieveUserDetails(target Target, authInfo api.AuthIn
 
 	jwt, err := jws.ParseJWT([]byte(idToken))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse user token for %s: %v", target.Name(), err)
+		return nil, fmt.Errorf("failed to parse user token for %s: %w", target.Name(), err)
 	}
 
 	user := jwt.Claims().Get("email")
@@ -113,11 +113,11 @@ func (r *ospreyRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*T
 
 	req, err := createAccessTokenRequest(target.Server(), r.credentials)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create access-token request: %v", err)
+		return nil, fmt.Errorf("unable to create access-token request: %w", err)
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve access-token: %v", err)
+		return nil, fmt.Errorf("failed to retrieve access-token: %w", err)
 	}
 	defer resp.Body.Close()
 	accessToken, err := pb.ConsumeLoginResponse(resp)
@@ -149,7 +149,7 @@ func createAccessTokenRequest(host string, credentials *LoginCredentials) (*http
 	url := fmt.Sprintf("%s/access-token", host)
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create access-token request: %v", err)
+		return nil, fmt.Errorf("unable to create access-token request: %w", err)
 	}
 	authToken := basicAuth(credentials)
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", authToken))
@@ -162,7 +162,7 @@ func createClusterInfoRequest(host string) (*http.Request, error) {
 	url := fmt.Sprintf("%s/cluster-info", host)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create cluster-info request: %v", err)
+		return nil, fmt.Errorf("unable to create cluster-info request: %w", err)
 	}
 	req.Header.Add("Accept", "application/octet-stream")
 
@@ -173,7 +173,7 @@ func createCAConfigMapRequest(host string) (*http.Request, error) {
 	url := fmt.Sprintf("%s/api/v1/namespaces/kube-public/configmaps/kube-root-ca.crt", host)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create CA ConfigMap request: %v", err)
+		return nil, fmt.Errorf("unable to create CA ConfigMap request: %w", err)
 	}
 	req.Header.Add("Accept", "application/json")
 

--- a/client/target.go
+++ b/client/target.go
@@ -32,6 +32,17 @@ func (m *Target) Server() string {
 	return m.targetEntry.Server
 }
 
+// APIServer returns the API server of the Target
+func (m *Target) APIServer() string {
+	return m.targetEntry.APIServer
+}
+
+// ShouldFetchCAFromAPIServer returns true iff the CA should be fetched from the kube-public ConfigMap
+// instead of the other methods (e.g. inline in Osprey config file or from Osprey server)
+func (m *Target) ShouldFetchCAFromAPIServer() bool {
+	return m.targetEntry.APIServer != ""
+}
+
 // ProviderType returns the authentication provider of the Target
 func (m *Target) ProviderType() string {
 	return m.providerType

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -48,7 +48,7 @@ func init() {
 
 func auth(cmd *cobra.Command, args []string) {
 	var service osprey.Osprey
-	httpClient, err := webClient.NewTLSClient()
+	httpClient, err := webClient.NewTLSClient(false)
 	issuerCAData, err := webClient.LoadTLSCert(issuerCA)
 	if err != nil {
 		log.Fatalf("Failed to load issuerCA: %v", err)
@@ -59,7 +59,7 @@ func auth(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load tls-cert: %v", err)
 	}
 
-	httpClient, err = webClient.NewTLSClient(issuerCAData, tlsCertData)
+	httpClient, err = webClient.NewTLSClient(false, issuerCAData, tlsCertData)
 	if err != nil {
 		log.Fatal("Failed to create http client")
 	}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -48,7 +48,7 @@ func init() {
 
 func auth(cmd *cobra.Command, args []string) {
 	var service osprey.Osprey
-	httpClient, err := webClient.NewTLSClient(false)
+	httpClient, err := webClient.NewTLSClient()
 	issuerCAData, err := webClient.LoadTLSCert(issuerCA)
 	if err != nil {
 		log.Fatalf("Failed to load issuerCA: %v", err)
@@ -59,7 +59,7 @@ func auth(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load tls-cert: %v", err)
 	}
 
-	httpClient, err = webClient.NewTLSClient(false, issuerCAData, tlsCertData)
+	httpClient, err = webClient.NewTLSClient(issuerCAData, tlsCertData)
 	if err != nil {
 		log.Fatal("Failed to create http client")
 	}

--- a/common/ioutil.go
+++ b/common/ioutil.go
@@ -19,5 +19,5 @@ func Input(inputName string, reader *bufio.Reader) (string, error) {
 		value = strings.TrimSpace(value)
 		return value, nil
 	}
-	return "", fmt.Errorf("reading %s: %w", inputName, err)
+	return "", fmt.Errorf("failed to read %s: %v", inputName, err)
 }

--- a/common/ioutil.go
+++ b/common/ioutil.go
@@ -19,5 +19,5 @@ func Input(inputName string, reader *bufio.Reader) (string, error) {
 		value = strings.TrimSpace(value)
 		return value, nil
 	}
-	return "", fmt.Errorf("failed to read %s: %v", inputName, err)
+	return "", fmt.Errorf("failed to read %s: %w", inputName, err)
 }

--- a/common/ioutil.go
+++ b/common/ioutil.go
@@ -19,5 +19,5 @@ func Input(inputName string, reader *bufio.Reader) (string, error) {
 		value = strings.TrimSpace(value)
 		return value, nil
 	}
-	return "", fmt.Errorf("failed to read %s: %v", inputName, err)
+	return "", fmt.Errorf("reading %s: %w", inputName, err)
 }

--- a/common/pb/util.go
+++ b/common/pb/util.go
@@ -19,13 +19,13 @@ func ConsumeLoginResponse(response *http.Response) (*LoginResponse, error) {
 	defer response.Body.Close()
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
+		return nil, fmt.Errorf("failed to read response: %v", err)
 	}
 	if response.StatusCode == http.StatusOK {
 		accessToken := &LoginResponse{}
 		err = proto.Unmarshal(data, accessToken)
 		if err != nil {
-			return nil, fmt.Errorf("parsing response: %w", err)
+			return nil, fmt.Errorf("failed to parse response: %v", err)
 		}
 		return accessToken, nil
 	}
@@ -37,14 +37,14 @@ func ConsumeLoginResponse(response *http.Response) (*LoginResponse, error) {
 func ConsumeClusterInfoResponse(response *http.Response) (*ClusterInfoResponse, error) {
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
+		return nil, fmt.Errorf("failed to read response: %v", err)
 	}
 	defer response.Body.Close()
 	if response.StatusCode == http.StatusOK {
 		clusterInfo := &ClusterInfoResponse{}
 		err = proto.Unmarshal(data, clusterInfo)
 		if err != nil {
-			return nil, fmt.Errorf("parsing response: %w", err)
+			return nil, fmt.Errorf("failed to parse response: %v", err)
 		}
 		return clusterInfo, nil
 	}
@@ -59,13 +59,13 @@ func HandleErrorResponse(body []byte, response *http.Response) (err error) {
 		err = proto.Unmarshal(body, s)
 		state := status.FromProto(s)
 		if err != nil {
-			return fmt.Errorf("parsing pb error response: %w", err)
+			return fmt.Errorf("failed to parse pb error response: %v", err)
 		}
 		return state.Err()
 	}
 	responseText, err := html2text.FromString(string(body), html2text.Options{PrettyTables: true})
 	if err != nil {
-		return fmt.Errorf("parsing HTML error response: %w", err)
+		return fmt.Errorf("failed to parse html error response: %v", err)
 	}
 	return fmt.Errorf("\n%s", responseText)
 }

--- a/common/pb/util.go
+++ b/common/pb/util.go
@@ -19,13 +19,13 @@ func ConsumeLoginResponse(response *http.Response) (*LoginResponse, error) {
 	defer response.Body.Close()
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %v", err)
+		return nil, fmt.Errorf("reading response: %w", err)
 	}
 	if response.StatusCode == http.StatusOK {
 		accessToken := &LoginResponse{}
 		err = proto.Unmarshal(data, accessToken)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse response: %v", err)
+			return nil, fmt.Errorf("parsing response: %w", err)
 		}
 		return accessToken, nil
 	}
@@ -37,14 +37,14 @@ func ConsumeLoginResponse(response *http.Response) (*LoginResponse, error) {
 func ConsumeClusterInfoResponse(response *http.Response) (*ClusterInfoResponse, error) {
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %v", err)
+		return nil, fmt.Errorf("reading response: %w", err)
 	}
 	defer response.Body.Close()
 	if response.StatusCode == http.StatusOK {
 		clusterInfo := &ClusterInfoResponse{}
 		err = proto.Unmarshal(data, clusterInfo)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse response: %v", err)
+			return nil, fmt.Errorf("parsing response: %w", err)
 		}
 		return clusterInfo, nil
 	}
@@ -59,13 +59,13 @@ func HandleErrorResponse(body []byte, response *http.Response) (err error) {
 		err = proto.Unmarshal(body, s)
 		state := status.FromProto(s)
 		if err != nil {
-			return fmt.Errorf("failed to parse pb error response: %v", err)
+			return fmt.Errorf("parsing pb error response: %w", err)
 		}
 		return state.Err()
 	}
 	responseText, err := html2text.FromString(string(body), html2text.Options{PrettyTables: true})
 	if err != nil {
-		return fmt.Errorf("failed to parse html error response: %v", err)
+		return fmt.Errorf("parsing HTML error response: %w", err)
 	}
 	return fmt.Errorf("\n%s", responseText)
 }

--- a/common/pb/util.go
+++ b/common/pb/util.go
@@ -19,13 +19,13 @@ func ConsumeLoginResponse(response *http.Response) (*LoginResponse, error) {
 	defer response.Body.Close()
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %v", err)
+		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 	if response.StatusCode == http.StatusOK {
 		accessToken := &LoginResponse{}
 		err = proto.Unmarshal(data, accessToken)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse response: %v", err)
+			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		return accessToken, nil
 	}
@@ -37,14 +37,14 @@ func ConsumeLoginResponse(response *http.Response) (*LoginResponse, error) {
 func ConsumeClusterInfoResponse(response *http.Response) (*ClusterInfoResponse, error) {
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %v", err)
+		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 	defer response.Body.Close()
 	if response.StatusCode == http.StatusOK {
 		clusterInfo := &ClusterInfoResponse{}
 		err = proto.Unmarshal(data, clusterInfo)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse response: %v", err)
+			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		return clusterInfo, nil
 	}
@@ -59,13 +59,13 @@ func HandleErrorResponse(body []byte, response *http.Response) (err error) {
 		err = proto.Unmarshal(body, s)
 		state := status.FromProto(s)
 		if err != nil {
-			return fmt.Errorf("failed to parse pb error response: %v", err)
+			return fmt.Errorf("failed to parse pb error response: %w", err)
 		}
 		return state.Err()
 	}
 	responseText, err := html2text.FromString(string(body), html2text.Options{PrettyTables: true})
 	if err != nil {
-		return fmt.Errorf("failed to parse html error response: %v", err)
+		return fmt.Errorf("failed to parse html error response: %w", err)
 	}
 	return fmt.Errorf("\n%s", responseText)
 }

--- a/common/web/client.go
+++ b/common/web/client.go
@@ -20,7 +20,7 @@ func LoadTLSCert(path string) (string, error) {
 	}
 	fileData, err := ioutil.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to read certificate file %q: %v", path, err)
+		return "", fmt.Errorf("reading certificate file %q: %w", path, err)
 	}
 	certData := base64.StdEncoding.EncodeToString(fileData)
 	return certData, nil
@@ -32,7 +32,7 @@ func NewTLSClient(caCerts ...string) (*http.Client, error) {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
 		if len(caCerts) == 0 {
-			return nil, fmt.Errorf("no CA certs specified and could not load the system's CA certs: %v", err)
+			return nil, fmt.Errorf("no CA certs specified and could not load the system's CA certs: %w", err)
 		}
 		certPool = x509.NewCertPool()
 	}
@@ -40,7 +40,7 @@ func NewTLSClient(caCerts ...string) (*http.Client, error) {
 		if ca != "" {
 			serverCA, err := base64.StdEncoding.DecodeString(ca)
 			if err != nil {
-				return nil, fmt.Errorf("failed to decode CA data: %v", err)
+				return nil, fmt.Errorf("decoding CA data: %w", err)
 			}
 
 			if !certPool.AppendCertsFromPEM(serverCA) {

--- a/common/web/client.go
+++ b/common/web/client.go
@@ -28,15 +28,15 @@ func LoadTLSCert(path string) (string, error) {
 
 // NewTLSClient creates a new http.Client configured for TLS. It uses the system
 // certs by default if possible and appends all of the provided certs.
-func NewTLSClient(skipVerify bool, certs ...string) (*http.Client, error) {
+func NewTLSClient(caCerts ...string) (*http.Client, error) {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
-		if len(certs) == 0 {
+		if len(caCerts) == 0 {
 			return nil, fmt.Errorf("no CA certs specified and could not load the system's CA certs: %v", err)
 		}
 		certPool = x509.NewCertPool()
 	}
-	for _, ca := range certs {
+	for _, ca := range caCerts {
 		if ca != "" {
 			serverCA, err := base64.StdEncoding.DecodeString(ca)
 			if err != nil {
@@ -49,6 +49,7 @@ func NewTLSClient(skipVerify bool, certs ...string) (*http.Client, error) {
 		}
 	}
 
+	skipVerify := len(caCerts) == 0
 	tlsConfig := &tls.Config{RootCAs: certPool, InsecureSkipVerify: skipVerify}
 
 	return &http.Client{

--- a/common/web/client.go
+++ b/common/web/client.go
@@ -20,7 +20,7 @@ func LoadTLSCert(path string) (string, error) {
 	}
 	fileData, err := ioutil.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to read certificate file %q: %v", path, err)
+		return "", fmt.Errorf("failed to read certificate file %q: %w", path, err)
 	}
 	certData := base64.StdEncoding.EncodeToString(fileData)
 	return certData, nil
@@ -32,7 +32,7 @@ func NewTLSClient(caCerts ...string) (*http.Client, error) {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
 		if len(caCerts) == 0 {
-			return nil, fmt.Errorf("no CA certs specified and could not load the system's CA certs: %v", err)
+			return nil, fmt.Errorf("no CA certs specified and could not load the system's CA certs: %w", err)
 		}
 		certPool = x509.NewCertPool()
 	}
@@ -40,7 +40,7 @@ func NewTLSClient(caCerts ...string) (*http.Client, error) {
 		if ca != "" {
 			serverCA, err := base64.StdEncoding.DecodeString(ca)
 			if err != nil {
-				return nil, fmt.Errorf("failed to decode CA data: %v", err)
+				return nil, fmt.Errorf("failed to decode CA data: %w", err)
 			}
 
 			if !certPool.AppendCertsFromPEM(serverCA) {

--- a/common/web/client.go
+++ b/common/web/client.go
@@ -28,7 +28,7 @@ func LoadTLSCert(path string) (string, error) {
 
 // NewTLSClient creates a new http.Client configured for TLS. It uses the system
 // certs by default if possible and appends all of the provided certs.
-func NewTLSClient(certs ...string) (*http.Client, error) {
+func NewTLSClient(skipVerify bool, certs ...string) (*http.Client, error) {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
 		if len(certs) == 0 {
@@ -49,7 +49,7 @@ func NewTLSClient(certs ...string) (*http.Client, error) {
 		}
 	}
 
-	tlsConfig := &tls.Config{RootCAs: certPool}
+	tlsConfig := &tls.Config{RootCAs: certPool, InsecureSkipVerify: skipVerify}
 
 	return &http.Client{
 		Transport: &http.Transport{

--- a/common/web/client.go
+++ b/common/web/client.go
@@ -20,7 +20,7 @@ func LoadTLSCert(path string) (string, error) {
 	}
 	fileData, err := ioutil.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("reading certificate file %q: %w", path, err)
+		return "", fmt.Errorf("failed to read certificate file %q: %v", path, err)
 	}
 	certData := base64.StdEncoding.EncodeToString(fileData)
 	return certData, nil
@@ -32,7 +32,7 @@ func NewTLSClient(caCerts ...string) (*http.Client, error) {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
 		if len(caCerts) == 0 {
-			return nil, fmt.Errorf("no CA certs specified and could not load the system's CA certs: %w", err)
+			return nil, fmt.Errorf("no CA certs specified and could not load the system's CA certs: %v", err)
 		}
 		certPool = x509.NewCertPool()
 	}
@@ -40,7 +40,7 @@ func NewTLSClient(caCerts ...string) (*http.Client, error) {
 		if ca != "" {
 			serverCA, err := base64.StdEncoding.DecodeString(ca)
 			if err != nil {
-				return nil, fmt.Errorf("decoding CA data: %w", err)
+				return nil, fmt.Errorf("failed to decode CA data: %v", err)
 			}
 
 			if !certPool.AppendCertsFromPEM(serverCA) {

--- a/e2e/apiservertest/server.go
+++ b/e2e/apiservertest/server.go
@@ -1,0 +1,109 @@
+package apiservertest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const rootCaRequestPath = "/api/v1/namespaces/kube-public/configmaps/kube-root-ca.crt"
+
+// Server holds the interface to a mocked API server
+type Server interface {
+	RequestCount(endpoint string) int
+	Reset()
+	Stop()
+}
+
+func (m *mockAPIServer) Reset() {
+	m.requestCount = initialiseRequestStates()
+}
+
+func (m *mockAPIServer) RequestCount(endpoint string) int {
+	return m.requestCount[endpoint]
+}
+
+type mockAPIServer struct {
+	URL          string
+	CACert       string
+	httpServer   *http.Server
+	requestCount map[string]int
+	mux          *http.ServeMux
+}
+
+func setup(m *mockAPIServer) *http.Server {
+	return &http.Server{
+		Addr:      m.URL,
+		Handler:   m.mux,
+		TLSConfig: nil,
+	}
+}
+
+func initialiseRequestStates() map[string]int {
+	endpoints := []string{
+		rootCaRequestPath,
+	}
+	requestStates := make(map[string]int)
+
+	for _, endpoint := range endpoints {
+		requestStates[endpoint] = 0
+	}
+
+	return requestStates
+}
+
+// Start returns and starts a new API test server
+func Start(host string, port int32) (Server, error) {
+	server := &mockAPIServer{
+		URL:          fmt.Sprintf("%s:%d", host, port),
+		requestCount: initialiseRequestStates(),
+		mux:          http.NewServeMux(),
+	}
+	server.httpServer = &http.Server{
+		Addr:      server.URL,
+		Handler:   server.mux,
+		TLSConfig: nil,
+	}
+
+	server.mux.Handle(rootCaRequestPath, handleRootCaRequest(server))
+
+	go func() {
+		if err := server.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("unable to start mock server: %v", err)
+		}
+	}()
+	return server, nil
+}
+
+func (m *mockAPIServer) Stop() {
+	if err := m.httpServer.Shutdown(context.Background()); err != nil {
+		fmt.Printf("unable to shutdown mock server: %v\n", err)
+	}
+}
+
+func handleRootCaRequest(m *mockAPIServer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		_, _ = w.Write([]byte(caConfigMapResponse))
+		m.requestCount[r.URL.Path]++
+	}
+}
+
+const (
+	// CaCertIdentifyingPortion a part of the CA to check when asserting that this particular CA was fetched
+	CaCertIdentifyingPortion = "MIIGhjCCBW6gAwIBAgITZgAEN7n0RPnqTqxkKAABAAQ3uTANBgkqhkiG9w0BAQsF"
+	caConfigMapResponse      = `
+{
+  "kind": "ConfigMap",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "kube-root-ca.crt",
+    "namespace": "kube-public"
+  },
+  "data": {
+    "ca.crt": "-----BEGIN CERTIFICATE-----\n` + CaCertIdentifyingPortion + `\nADBNMRMwEQYKCZImiZPyLGQBGRYDY29tMRUwEwYKCZImiZPyLGQBGRYFYnNreWIx\nHzAdBgNVBAMTFk5FVy1CU0tZQi1JU1NVSU5HLUNBMDEwHhcNMjAxMDEyMDkxNDU3\nWhcNMjExMTE0MDkxNDU3WjB0MQswCQYDVQQGEwJHQjESMBAGA1UECBMJTWlkZGxl\nc2V4MRIwEAYDVQQHEwlJc2xld29ydGgxEDAOBgNVBAoTB1NLWSBQTEMxDjAMBgNV\nBAsTBUdUVkRQMRswGQYDVQQDExJzYW5kZnVuLmNvc21pYy5za3kwggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAAET6KrNlTQAXPvpU644VliPHBWu6CFmE\nivK6Bm1WMCZPhD/Zarsl+mXKW594KJDoVaA+DMzwAo/hYnHWoV5wzSPdJb76OI5k\nUmBQhYKwr/JqPp/Fz0cTbnG5WYbot/8NQjD6b1yzQq+tiB2OFRoAVcBrlIgRZCwE\nEI2QrLx+xJVGFaPQHSyzAW7ym5Qy/E1oxK2inc3iRYKOjwaqJl1DOdPhY67kmvv6\nd4TsI9zP/MYsLW/ndD+mwWXQiEDVStYHhr33447DSKb7ese+202U10zd8XjkPr+T\n91XuiqyTmJ23TK1YznsNvUxVXHjWPmCIzZQCf05gnr15j1l74V9JAgMBAAGjggM2\nMIIDMjALBgNVHQ8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwNwYDVR0RBDAw\nLoIUKi5zYW5kZnVuLmNvc21pYy5za3mCFioucy5zYW5kZnVuLmNvc21pYy5za3kw\nHQYDVR0OBBYEFA/c0xCQTCuHCYtvo+dE3UbreIbiMB8GA1UdIwQYMBaAFL5qnAMG\nDIL0CNps8PhIXXgn7fzsMIIBGwYDVR0fBIIBEjCCAQ4wggEKoIIBBqCCAQKGgbxs\nZGFwOi8vL0NOPU5FVy1CU0tZQi1JU1NVSU5HLUNBMDEsQ049V1BDQUkwMTAsQ049\nQ0RQLENOPVB1YmxpYyUyMEtleSUyMFNlcnZpY2VzLENOPVNlcnZpY2VzLENOPUNv\nbmZpZ3VyYXRpb24sREM9YnNreWIsREM9Y29tP2NlcnRpZmljYXRlUmV2b2NhdGlv\nbkxpc3Q/YmFzZT9vYmplY3RDbGFzcz1jUkxEaXN0cmlidXRpb25Qb2ludIZBaHR0\ncDovL2NlcnRpZmljYXRlcy5ic2t5Yi5jb20vQ2VydERhdGEvTkVXLUJTS1lCLUlT\nU1VJTkctQ0EwMS5jcmwwggEaBggrBgEFBQcBAQSCAQwwggEIMIGzBggrBgEFBQcw\nAoaBpmxkYXA6Ly8vQ049TkVXLUJTS1lCLUlTU1VJTkctQ0EwMSxDTj1BSUEsQ049\nUHVibGljJTIwS2V5JTIwU2VydmljZXMsQ049U2VydmljZXMsQ049Q29uZmlndXJh\ndGlvbixEQz1ic2t5YixEQz1jb20/Y0FDZXJ0aWZpY2F0ZT9iYXNlP29iamVjdENs\nYXNzPWNlcnRpZmljYXRpb25BdXRob3JpdHkwUAYIKwYBBQUHMAKGRGh0dHA6Ly9j\nZXJ0aWZpY2F0ZXMuYnNreWIuY29tL0NlcnREYXRhL05FVy1CU0tZQi1JU1NVSU5H\nLUNBMDEoMSkuY3J0MDsGCSsGAQQBgjcVBwQuMCwGJCsGAQQBgjcVCIec8CaBi9Zk\nh5GLCK/lB4a83iQYwoEHhsnQcAIBZAIBCjAbBgkrBgEEAYI3FQoEDjAMMAoGCCsG\nAQUFBwMBMA0GCSqGSIb3DQEBCwUAA4IBAQAWfuUY1TgWvHR7agr/zv3NzHrQ+NqI\nITDzLyCDwo2511fhuMYl5uAylp2uCQfwTVbMHY3Uktd1VcHFVzrHCvJpzrP+9sFw\nQ/paDzWc3i+wtffFpMZD9rzy4C+oYQLM7LGjg1nGWPrseM4iRt0ImH1zbyiNWOUM\n/EcC/T3lENmpLH5DHNF1C/wY1NBqiOs4Hqcwtc1rewkX+9f1vuX3m88r9QrJqDd1\nf5OJYejZW0lv8BkA0lPcHGvsBdNaeV6mV3EJ+hu8lo5GVGw4cF2+88wNXccV2d3V\nufyNNGlrVt9iS/qRE/Uo4iluGwg/QElvnY+hgK4fVRFU0fKdwbNQgaiF\n-----END CERTIFICATE-----"
+  }
+}`
+)

--- a/e2e/clitest/async_command.go
+++ b/e2e/clitest/async_command.go
@@ -126,6 +126,7 @@ func (c *asyncCommandWrapper) AssertSuccess() {
 }
 
 func (c *asyncCommandWrapper) EventuallyAssertSuccess(timeoutDuration, pollingInterval time.Duration) {
+	c.finishedFlag.Wait()
 	assertNoExitError(c.GetOutput(), c.error)
 	gomega.Eventually(func() bool {
 		c.Lock()

--- a/e2e/dextest/server.go
+++ b/e2e/dextest/server.go
@@ -59,7 +59,7 @@ func StartDexes(testDir string, ldap *ldaptest.TestLDAP, environments []string, 
 			dexes = append(dexes, aDex)
 		}
 		if err != nil {
-			return dexes, fmt.Errorf("creating dex server for environment %s (port: %d): %w", env, port, err)
+			return dexes, fmt.Errorf("failed to create dex server for environment %s (port: %d): %v", env, port, err)
 		}
 	}
 
@@ -102,7 +102,7 @@ func newServerWithTLS(ctx context.Context, dexCA, dexKey string, port int32, env
 
 	server, err = dex.NewServer(ctx, *config)
 	if err != nil {
-		return nil, fmt.Errorf("starting server: %w", err)
+		return nil, fmt.Errorf("failed to start server: %v", err)
 	}
 
 	httpServer, err := setupHTTPS(dexCA, dexKey, port, server)
@@ -128,7 +128,7 @@ func newServerWithTLS(ctx context.Context, dexCA, dexKey string, port int32, env
 func createLdapConnector(ldapConfig *dex_ldap.Config, config *dex.Config) error {
 	ldapConfigBytes, err := json.Marshal(ldapConfig)
 	if err != nil {
-		return fmt.Errorf("marshalling ldapConfig: %w", err)
+		return fmt.Errorf("failed to mashal ldapConfig: %v", err)
 	}
 	connector := dex_storage.Connector{
 		ID:     "ldap",
@@ -137,7 +137,7 @@ func createLdapConnector(ldapConfig *dex_ldap.Config, config *dex.Config) error 
 		Config: ldapConfigBytes,
 	}
 	if err = config.Storage.CreateConnector(connector); err != nil {
-		return fmt.Errorf("creating LDAP connector: %w", err)
+		return fmt.Errorf("failed to create ldap connector: %v", err)
 	}
 	return nil
 }

--- a/e2e/dextest/server.go
+++ b/e2e/dextest/server.go
@@ -59,7 +59,7 @@ func StartDexes(testDir string, ldap *ldaptest.TestLDAP, environments []string, 
 			dexes = append(dexes, aDex)
 		}
 		if err != nil {
-			return dexes, fmt.Errorf("failed to create dex server for environment %s (port: %d): %v", env, port, err)
+			return dexes, fmt.Errorf("failed to create dex server for environment %s (port: %d): %w", env, port, err)
 		}
 	}
 
@@ -102,7 +102,7 @@ func newServerWithTLS(ctx context.Context, dexCA, dexKey string, port int32, env
 
 	server, err = dex.NewServer(ctx, *config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start server: %v", err)
+		return nil, fmt.Errorf("failed to start server: %w", err)
 	}
 
 	httpServer, err := setupHTTPS(dexCA, dexKey, port, server)
@@ -128,7 +128,7 @@ func newServerWithTLS(ctx context.Context, dexCA, dexKey string, port int32, env
 func createLdapConnector(ldapConfig *dex_ldap.Config, config *dex.Config) error {
 	ldapConfigBytes, err := json.Marshal(ldapConfig)
 	if err != nil {
-		return fmt.Errorf("failed to mashal ldapConfig: %v", err)
+		return fmt.Errorf("failed to mashal ldapConfig: %w", err)
 	}
 	connector := dex_storage.Connector{
 		ID:     "ldap",
@@ -137,7 +137,7 @@ func createLdapConnector(ldapConfig *dex_ldap.Config, config *dex.Config) error 
 		Config: ldapConfigBytes,
 	}
 	if err = config.Storage.CreateConnector(connector); err != nil {
-		return fmt.Errorf("failed to create ldap connector: %v", err)
+		return fmt.Errorf("failed to create ldap connector: %w", err)
 	}
 	return nil
 }

--- a/e2e/dextest/server.go
+++ b/e2e/dextest/server.go
@@ -59,7 +59,7 @@ func StartDexes(testDir string, ldap *ldaptest.TestLDAP, environments []string, 
 			dexes = append(dexes, aDex)
 		}
 		if err != nil {
-			return dexes, fmt.Errorf("failed to create dex server for environment %s (port: %d): %v", env, port, err)
+			return dexes, fmt.Errorf("creating dex server for environment %s (port: %d): %w", env, port, err)
 		}
 	}
 
@@ -102,7 +102,7 @@ func newServerWithTLS(ctx context.Context, dexCA, dexKey string, port int32, env
 
 	server, err = dex.NewServer(ctx, *config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start server: %v", err)
+		return nil, fmt.Errorf("starting server: %w", err)
 	}
 
 	httpServer, err := setupHTTPS(dexCA, dexKey, port, server)
@@ -128,7 +128,7 @@ func newServerWithTLS(ctx context.Context, dexCA, dexKey string, port int32, env
 func createLdapConnector(ldapConfig *dex_ldap.Config, config *dex.Config) error {
 	ldapConfigBytes, err := json.Marshal(ldapConfig)
 	if err != nil {
-		return fmt.Errorf("failed to mashal ldapConfig: %v", err)
+		return fmt.Errorf("marshalling ldapConfig: %w", err)
 	}
 	connector := dex_storage.Connector{
 		ID:     "ldap",
@@ -137,7 +137,7 @@ func createLdapConnector(ldapConfig *dex_ldap.Config, config *dex.Config) error 
 		Config: ldapConfigBytes,
 	}
 	if err = config.Storage.CreateConnector(connector); err != nil {
-		return fmt.Errorf("failed to create ldap connector: %v", err)
+		return fmt.Errorf("creating LDAP connector: %w", err)
 	}
 	return nil
 }

--- a/e2e/ldaptest/server.go
+++ b/e2e/ldaptest/server.go
@@ -139,16 +139,16 @@ func generateSLAPDConfig(ldapDir string) (config *SLAPDConfig, err error) {
 func writeTemplateToFile(templatePath, targetPath string, config interface{}) error {
 	t, err := template.ParseFiles(templatePath)
 	if err != nil {
-		return fmt.Errorf("failed to parse %s: %v", templatePath, err)
+		return fmt.Errorf("failed to parse %s: %w", templatePath, err)
 	}
 	file, err := os.Create(targetPath)
 	if err != nil {
-		return fmt.Errorf("failed to create %s: %v", targetPath, err)
+		return fmt.Errorf("failed to create %s: %w", targetPath, err)
 	}
 	defer file.Close()
 	err = t.Execute(file, config)
 	if err != nil {
-		return fmt.Errorf("failed to write %s: %v", targetPath, err)
+		return fmt.Errorf("failed to write %s: %w", targetPath, err)
 	}
 	return nil
 }
@@ -167,7 +167,7 @@ func includes(wd string) (paths []string, err error) {
 	for _, f := range includeFiles {
 		p := filepath.Join(wd, f)
 		if _, err := os.Stat(p); err != nil {
-			return []string{}, fmt.Errorf("failed to find schema file: %s %v", p, err)
+			return []string{}, fmt.Errorf("failed to find schema file: %s %w", p, err)
 		}
 		paths = append(paths, p)
 	}

--- a/e2e/ldaptest/server.go
+++ b/e2e/ldaptest/server.go
@@ -139,16 +139,16 @@ func generateSLAPDConfig(ldapDir string) (config *SLAPDConfig, err error) {
 func writeTemplateToFile(templatePath, targetPath string, config interface{}) error {
 	t, err := template.ParseFiles(templatePath)
 	if err != nil {
-		return fmt.Errorf("parsing %s: %w", templatePath, err)
+		return fmt.Errorf("failed to parse %s: %v", templatePath, err)
 	}
 	file, err := os.Create(targetPath)
 	if err != nil {
-		return fmt.Errorf("creating %s: %w", targetPath, err)
+		return fmt.Errorf("failed to create %s: %v", targetPath, err)
 	}
 	defer file.Close()
 	err = t.Execute(file, config)
 	if err != nil {
-		return fmt.Errorf("writing %s: %w", targetPath, err)
+		return fmt.Errorf("failed to write %s: %v", targetPath, err)
 	}
 	return nil
 }
@@ -167,7 +167,7 @@ func includes(wd string) (paths []string, err error) {
 	for _, f := range includeFiles {
 		p := filepath.Join(wd, f)
 		if _, err := os.Stat(p); err != nil {
-			return []string{}, fmt.Errorf("finding schema file: %s %w", p, err)
+			return []string{}, fmt.Errorf("failed to find schema file: %s %v", p, err)
 		}
 		paths = append(paths, p)
 	}

--- a/e2e/ldaptest/server.go
+++ b/e2e/ldaptest/server.go
@@ -139,16 +139,16 @@ func generateSLAPDConfig(ldapDir string) (config *SLAPDConfig, err error) {
 func writeTemplateToFile(templatePath, targetPath string, config interface{}) error {
 	t, err := template.ParseFiles(templatePath)
 	if err != nil {
-		return fmt.Errorf("failed to parse %s: %v", templatePath, err)
+		return fmt.Errorf("parsing %s: %w", templatePath, err)
 	}
 	file, err := os.Create(targetPath)
 	if err != nil {
-		return fmt.Errorf("failed to create %s: %v", targetPath, err)
+		return fmt.Errorf("creating %s: %w", targetPath, err)
 	}
 	defer file.Close()
 	err = t.Execute(file, config)
 	if err != nil {
-		return fmt.Errorf("failed to write %s: %v", targetPath, err)
+		return fmt.Errorf("writing %s: %w", targetPath, err)
 	}
 	return nil
 }
@@ -167,7 +167,7 @@ func includes(wd string) (paths []string, err error) {
 	for _, f := range includeFiles {
 		p := filepath.Join(wd, f)
 		if _, err := os.Stat(p); err != nil {
-			return []string{}, fmt.Errorf("failed to find schema file: %s %v", p, err)
+			return []string{}, fmt.Errorf("finding schema file: %s %w", p, err)
 		}
 		paths = append(paths, p)
 	}

--- a/e2e/logout_test.go
+++ b/e2e/logout_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Logout", func() {
 	})
 
 	JustBeforeEach(func() {
-		setupClientForEnvironments(ospreyProviderName, environmentsToUse, "")
+		setupClientForEnvironments(ospreyProviderName, environmentsToUse, "", "")
 
 		login = Login("user", "login", ospreyconfigFlag, targetGroupFlag)
 		logout = Client("user", "logout", ospreyconfigFlag, targetGroupFlag)

--- a/e2e/oidc_login_test.go
+++ b/e2e/oidc_login_test.go
@@ -254,14 +254,14 @@ func doOIDCMockRequest(endpoint, clientID, redirectURI, state string, scopes []s
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d%s?%s", oidcPort, endpoint, httpParameters.Encode()), nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create request: %v", err)
+		return nil, fmt.Errorf("unable to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch response: %v", err)
+		return nil, fmt.Errorf("unable to fetch response: %w", err)
 	}
 
 	time.Sleep(time.Second)

--- a/e2e/oidc_login_test.go
+++ b/e2e/oidc_login_test.go
@@ -254,14 +254,14 @@ func doOIDCMockRequest(endpoint, clientID, redirectURI, state string, scopes []s
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d%s?%s", oidcPort, endpoint, httpParameters.Encode()), nil)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create request: %v", err)
+		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch response: %v", err)
+		return nil, fmt.Errorf("fetching response: %w", err)
 	}
 
 	time.Sleep(time.Second)

--- a/e2e/oidc_login_test.go
+++ b/e2e/oidc_login_test.go
@@ -254,14 +254,14 @@ func doOIDCMockRequest(endpoint, clientID, redirectURI, state string, scopes []s
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d%s?%s", oidcPort, endpoint, httpParameters.Encode()), nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return nil, fmt.Errorf("unable to create request: %v", err)
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetching response: %w", err)
+		return nil, fmt.Errorf("unable to fetch response: %v", err)
 	}
 
 	time.Sleep(time.Second)

--- a/e2e/oidc_login_test.go
+++ b/e2e/oidc_login_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sky-uk/osprey/e2e/apiservertest"
+
 	"github.com/sky-uk/osprey/client/kubeconfig"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -35,7 +37,7 @@ var _ = Describe("Login with a cloud provider", func() {
 	})
 
 	JustBeforeEach(func() {
-		setupClientForEnvironments(azureProviderName, environmentsToUse, oidcClientID)
+		setupClientForEnvironments(azureProviderName, environmentsToUse, oidcClientID, apiServerURL)
 		userLoginArgs = []string{"user", "login", ospreyconfigFlag, "--disable-browser-popup"}
 	})
 
@@ -50,6 +52,7 @@ var _ = Describe("Login with a cloud provider", func() {
 	Context("using OIDC callback (--use-device-code=false)", func() {
 		AfterEach(func() {
 			oidcTestServer.Reset()
+			apiTestServer.Reset()
 		})
 		It("receives a token and decodes the JWT for user details", func() {
 			By("logging in", func() {
@@ -68,8 +71,38 @@ var _ = Describe("Login with a cloud provider", func() {
 			})
 		})
 
+		Describe("fetches the CA from the requested location", func() {
+			Describe("with api-server not defined in osprey config", func() {
+				It("should fetch from the Osprey server", func() {
+					login := loginCommand(ospreyBinary, userLoginArgs...)
+
+					_, err := doOIDCMockRequest("/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
+					Expect(err).NotTo(HaveOccurred())
+
+					login.AssertSuccess()
+				})
+			})
+
+			Describe("with api-server defined in osprey config", func() {
+				BeforeEach(func() {
+					apiServerURL = fmt.Sprintf("http://localhost:%d", apiServerPort)
+				})
+				It("should fetch from the API Server", func() {
+					login := loginCommand(ospreyBinary, userLoginArgs...)
+
+					_, err := doOIDCMockRequest("/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
+					Expect(err).NotTo(HaveOccurred())
+
+					login.AssertSuccess()
+					Expect(apiTestServer.RequestCount("/api/v1/namespaces/kube-public/configmaps/kube-root-ca.crt")).To(Equal(1))
+					kubeconfig := getKubeConfig()
+					Expect(kubeconfig.Clusters["kubectl.local"].CertificateAuthorityData).To(ContainSubstring(apiservertest.CaCertIdentifyingPortion))
+				})
+			})
+		})
+
 		It("provides the same JWT token for multiple targets in group for the same provider", func() {
-			setupClientForEnvironments(azureProviderName, map[string][]string{"dev": {"development"}, "stage": {"development"}}, oidcClientID)
+			setupClientForEnvironments(azureProviderName, map[string][]string{"dev": {"development"}, "stage": {"development"}}, oidcClientID, "")
 			targetGroupArgs := append(userLoginArgs, "--group=development")
 			login := loginCommand(ospreyBinary, targetGroupArgs...)
 
@@ -108,7 +141,7 @@ var _ = Describe("Login with a cloud provider", func() {
 		})
 
 		It("provides the same JWT token for multiple targets in group for the same provider", func() {
-			setupClientForEnvironments(azureProviderName, map[string][]string{"dev": {"development"}, "stage": {"development"}}, oidcClientID)
+			setupClientForEnvironments(azureProviderName, map[string][]string{"dev": {"development"}, "stage": {"development"}}, oidcClientID, "")
 			targetGroupArgs := append(userLoginArgs, "--group=development", "--use-device-code")
 			login := loginCommand(ospreyBinary, targetGroupArgs...)
 
@@ -124,7 +157,7 @@ var _ = Describe("Login with a cloud provider", func() {
 		})
 
 		It("Polls the token endpoint at server specified intervals when token status is pending", func() {
-			setupClientForEnvironments(azureProviderName, environmentsToUse, "pending_client_id")
+			setupClientForEnvironments(azureProviderName, environmentsToUse, "pending_client_id", "")
 			useDeviceCodeArgs := append(userLoginArgs, "--use-device-code")
 			login := loginCommand(ospreyBinary, useDeviceCodeArgs...)
 
@@ -137,7 +170,7 @@ var _ = Describe("Login with a cloud provider", func() {
 		})
 
 		It("Handles client id is not authorised error code", func() {
-			setupClientForEnvironments(azureProviderName, environmentsToUse, "bad_verification_client_id")
+			setupClientForEnvironments(azureProviderName, environmentsToUse, "bad_verification_client_id", "")
 			useDeviceCodeArgs := append(userLoginArgs, "--use-device-code")
 			login := loginCommand(ospreyBinary, useDeviceCodeArgs...)
 
@@ -148,7 +181,7 @@ var _ = Describe("Login with a cloud provider", func() {
 		})
 
 		It("Handles device code expired error code", func() {
-			setupClientForEnvironments(azureProviderName, environmentsToUse, "expired_client_id")
+			setupClientForEnvironments(azureProviderName, environmentsToUse, "expired_client_id", "")
 			useDeviceCodeArgs := append(userLoginArgs, "--use-device-code")
 			login := loginCommand(ospreyBinary, useDeviceCodeArgs...)
 
@@ -161,7 +194,7 @@ var _ = Describe("Login with a cloud provider", func() {
 
 	Context("Specifiying the --login-timeout flag", func() {
 		It("logs in successfully if the flow is complete before the timeout", func() {
-			setupClientForEnvironments(azureProviderName, environmentsToUse, "login_timeout_exceeded_client_id")
+			setupClientForEnvironments(azureProviderName, environmentsToUse, "login_timeout_exceeded_client_id", "")
 			timeoutArgs := append(userLoginArgs, "--login-timeout=20s")
 			login := loginCommand(ospreyBinary, timeoutArgs...)
 
@@ -172,7 +205,7 @@ var _ = Describe("Login with a cloud provider", func() {
 		})
 
 		It("callback flow times out if not logged in within the stipulated time", func() {
-			setupClientForEnvironments(azureProviderName, environmentsToUse, "login_timeout_exceeded_client_id")
+			setupClientForEnvironments(azureProviderName, environmentsToUse, "login_timeout_exceeded_client_id", "")
 			timeoutArgs := append(userLoginArgs, "--login-timeout=1s")
 			login := loginCommand(ospreyBinary, timeoutArgs...)
 
@@ -181,7 +214,7 @@ var _ = Describe("Login with a cloud provider", func() {
 		})
 
 		It("device-code flow times out if not logged in within the stipulated time", func() {
-			setupClientForEnvironments(azureProviderName, environmentsToUse, "login_timeout_exceeded_client_id")
+			setupClientForEnvironments(azureProviderName, environmentsToUse, "login_timeout_exceeded_client_id", "")
 			deviceCodeTimeoutArgs := append(userLoginArgs, "--use-device-code=true", "--login-timeout=1s")
 			login := loginCommand(ospreyBinary, deviceCodeTimeoutArgs...)
 

--- a/e2e/oidctest/server.go
+++ b/e2e/oidctest/server.go
@@ -244,17 +244,17 @@ func returnAuthRequest(callbackURL string) error {
 	successfulLoginResponse, _ := url.Parse(fmt.Sprintf("%s?state=%s&code=AWORKINGJTW", callbackURL, ospreyState))
 	resp, err := http.PostForm(successfulLoginResponse.String(), nil)
 	if err != nil {
-		return fmt.Errorf("posting form: %w", err)
+		return fmt.Errorf("unable to post form: %v", err)
 	}
 	defer resp.Body.Close()
 
 	_, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("reading body: %w", err)
+		return fmt.Errorf("unable to read body: %v", err)
 	}
 
 	if err != nil {
-		return fmt.Errorf("creating call-back request: %w", err)
+		return fmt.Errorf("unable to create call-back request: %v", err)
 	}
 	return nil
 }

--- a/e2e/oidctest/server.go
+++ b/e2e/oidctest/server.go
@@ -244,17 +244,17 @@ func returnAuthRequest(callbackURL string) error {
 	successfulLoginResponse, _ := url.Parse(fmt.Sprintf("%s?state=%s&code=AWORKINGJTW", callbackURL, ospreyState))
 	resp, err := http.PostForm(successfulLoginResponse.String(), nil)
 	if err != nil {
-		return fmt.Errorf("unable to post form: %v", err)
+		return fmt.Errorf("unable to post form: %w", err)
 	}
 	defer resp.Body.Close()
 
 	_, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("unable to read body: %v", err)
+		return fmt.Errorf("unable to read body: %w", err)
 	}
 
 	if err != nil {
-		return fmt.Errorf("unable to create call-back request: %v", err)
+		return fmt.Errorf("unable to create call-back request: %w", err)
 	}
 	return nil
 }

--- a/e2e/oidctest/server.go
+++ b/e2e/oidctest/server.go
@@ -244,17 +244,17 @@ func returnAuthRequest(callbackURL string) error {
 	successfulLoginResponse, _ := url.Parse(fmt.Sprintf("%s?state=%s&code=AWORKINGJTW", callbackURL, ospreyState))
 	resp, err := http.PostForm(successfulLoginResponse.String(), nil)
 	if err != nil {
-		return fmt.Errorf("unable to post form: %v", err)
+		return fmt.Errorf("posting form: %w", err)
 	}
 	defer resp.Body.Close()
 
 	_, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("unable to read body: %v", err)
+		return fmt.Errorf("reading body: %w", err)
 	}
 
 	if err != nil {
-		return fmt.Errorf("unable to create call-back request: %v", err)
+		return fmt.Errorf("creating call-back request: %w", err)
 	}
 	return nil
 }

--- a/e2e/ospreytest/fixtures.go
+++ b/e2e/ospreytest/fixtures.go
@@ -139,7 +139,7 @@ func (o *TestOsprey) ToGroupClaims(authInfo *clientgo.AuthInfo) ([]string, error
 // CallHealthcheck returns the current status of osprey's healthcheck as an http response and error
 func (o *TestOsprey) CallHealthcheck() (*http.Response, error) {
 	certData, _ := web.LoadTLSCert(o.CertFile)
-	httpClient, err := web.NewTLSClient(false, certData)
+	httpClient, err := web.NewTLSClient(certData)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/ospreytest/fixtures.go
+++ b/e2e/ospreytest/fixtures.go
@@ -23,7 +23,7 @@ const targetAliasPrefix = "alias."
 func AddCustomNamespaceToContexts(namespaceSuffix, kubeconfig string, targetedOspreys []*TestOsprey) error {
 	existingConfig, err := clientcmd.LoadFromFile(kubeconfig)
 	if err != nil {
-		return fmt.Errorf("unable to load kubeconfig file %s: %v", kubeconfig, err)
+		return fmt.Errorf("unable to load kubeconfig file %s: %w", kubeconfig, err)
 	}
 	for _, target := range targetedOspreys {
 		targetName := target.OspreyconfigTargetName()
@@ -34,7 +34,7 @@ func AddCustomNamespaceToContexts(namespaceSuffix, kubeconfig string, targetedOs
 	}
 	err = clientcmd.WriteToFile(*existingConfig, kubeconfig)
 	if err != nil {
-		return fmt.Errorf("unable to write kubeconfig file %s: %v", kubeconfig, err)
+		return fmt.Errorf("unable to write kubeconfig file %s: %w", kubeconfig, err)
 	}
 	return nil
 }

--- a/e2e/ospreytest/fixtures.go
+++ b/e2e/ospreytest/fixtures.go
@@ -139,7 +139,7 @@ func (o *TestOsprey) ToGroupClaims(authInfo *clientgo.AuthInfo) ([]string, error
 // CallHealthcheck returns the current status of osprey's healthcheck as an http response and error
 func (o *TestOsprey) CallHealthcheck() (*http.Response, error) {
 	certData, _ := web.LoadTLSCert(o.CertFile)
-	httpClient, err := web.NewTLSClient(certData)
+	httpClient, err := web.NewTLSClient(false, certData)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/ospreytest/fixtures.go
+++ b/e2e/ospreytest/fixtures.go
@@ -23,7 +23,7 @@ const targetAliasPrefix = "alias."
 func AddCustomNamespaceToContexts(namespaceSuffix, kubeconfig string, targetedOspreys []*TestOsprey) error {
 	existingConfig, err := clientcmd.LoadFromFile(kubeconfig)
 	if err != nil {
-		return fmt.Errorf("unable to load kubeconfig file %s: %v", kubeconfig, err)
+		return fmt.Errorf("loading kubeconfig file %s: %w", kubeconfig, err)
 	}
 	for _, target := range targetedOspreys {
 		targetName := target.OspreyconfigTargetName()
@@ -34,7 +34,7 @@ func AddCustomNamespaceToContexts(namespaceSuffix, kubeconfig string, targetedOs
 	}
 	err = clientcmd.WriteToFile(*existingConfig, kubeconfig)
 	if err != nil {
-		return fmt.Errorf("unable to write kubeconfig file %s: %v", kubeconfig, err)
+		return fmt.Errorf("writing kubeconfig file %s: %w", kubeconfig, err)
 	}
 	return nil
 }

--- a/e2e/ospreytest/fixtures.go
+++ b/e2e/ospreytest/fixtures.go
@@ -23,7 +23,7 @@ const targetAliasPrefix = "alias."
 func AddCustomNamespaceToContexts(namespaceSuffix, kubeconfig string, targetedOspreys []*TestOsprey) error {
 	existingConfig, err := clientcmd.LoadFromFile(kubeconfig)
 	if err != nil {
-		return fmt.Errorf("loading kubeconfig file %s: %w", kubeconfig, err)
+		return fmt.Errorf("unable to load kubeconfig file %s: %v", kubeconfig, err)
 	}
 	for _, target := range targetedOspreys {
 		targetName := target.OspreyconfigTargetName()
@@ -34,7 +34,7 @@ func AddCustomNamespaceToContexts(namespaceSuffix, kubeconfig string, targetedOs
 	}
 	err = clientcmd.WriteToFile(*existingConfig, kubeconfig)
 	if err != nil {
-		return fmt.Errorf("writing kubeconfig file %s: %w", kubeconfig, err)
+		return fmt.Errorf("unable to write kubeconfig file %s: %v", kubeconfig, err)
 	}
 	return nil
 }

--- a/e2e/ospreytest/server.go
+++ b/e2e/ospreytest/server.go
@@ -116,22 +116,28 @@ func Stop(server *TestOsprey) error {
 
 // BuildConfig creates an ospreyconfig file using the groups provided for the targets.
 // It uses testDir as the home for the .kube and .osprey folders.
-func BuildConfig(testDir, providerName, defaultGroup string, targetGroups map[string][]string, servers []*TestOsprey, clientID string) (*TestConfig, error) {
-	return BuildFullConfig(testDir, providerName, defaultGroup, targetGroups, servers, false, "", clientID)
+func BuildConfig(testDir, providerName, defaultGroup string, targetGroups map[string][]string,
+	servers []*TestOsprey, clientID, apiServerURL string) (*TestConfig, error) {
+	return BuildFullConfig(testDir, providerName, defaultGroup, targetGroups, servers,
+		false, "", clientID, apiServerURL)
 }
 
 // BuildCADataConfig creates an ospreyconfig file with as many targets as servers are provided.
 // It uses testDir as the home for the .kube and .osprey folders.
 // It also base64 encodes the CA data instead of using the file path.
-func BuildCADataConfig(testDir, providerName string, servers []*TestOsprey, caData bool, caPath string, clientID string) (*TestConfig, error) {
-	return BuildFullConfig(testDir, providerName, "", map[string][]string{}, servers, caData, caPath, clientID)
+func BuildCADataConfig(testDir, providerName string, servers []*TestOsprey,
+	caData bool, caPath, clientID, apiServerURL string) (*TestConfig, error) {
+	return BuildFullConfig(testDir, providerName, "", map[string][]string{}, servers,
+		caData, caPath, clientID, apiServerURL)
 }
 
 // BuildFullConfig creates an ospreyconfig file with as many targets as servers are provided. The targets will contain
 // the groups that have been specified.
 // It uses testDir as the home for the .kube and .osprey folders.
 // If caData is true, it base64 encodes the CA data instead of using the file path.
-func BuildFullConfig(testDir, providerName, defaultGroup string, targetGroups map[string][]string, servers []*TestOsprey, caData bool, caPath string, clientID string) (*TestConfig, error) {
+func BuildFullConfig(testDir, providerName, defaultGroup string,
+	targetGroups map[string][]string, servers []*TestOsprey,
+	caData bool, caPath, clientID, apiServerURL string) (*TestConfig, error) {
 	config := client.NewConfig()
 	config.Kubeconfig = fmt.Sprintf("%s/.kube/config", testDir)
 	ospreyconfigFile := fmt.Sprintf("%s/.osprey/config", testDir)
@@ -149,8 +155,14 @@ func BuildFullConfig(testDir, providerName, defaultGroup string, targetGroups ma
 		targetName := osprey.OspreyconfigTargetName()
 
 		target := &client.TargetEntry{
-			Server:  osprey.URL,
 			Aliases: []string{osprey.OspreyconfigAliasName()},
+		}
+
+		shouldFetchCAFromAPIServer := apiServerURL != ""
+		if shouldFetchCAFromAPIServer {
+			target.APIServer = apiServerURL
+		} else {
+			target.Server = osprey.URL
 		}
 
 		if caData {

--- a/e2e/targets_test.go
+++ b/e2e/targets_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Targets", func() {
 	})
 
 	JustBeforeEach(func() {
-		setupClientForEnvironments(ospreyProviderName, environmentsToUse, "")
+		setupClientForEnvironments(ospreyProviderName, environmentsToUse, "", "")
 		targets = Client("config", "targets", ospreyconfigFlag, targetGroupFlag, byGroupsFlag, listGroupsFlag)
 	})
 

--- a/e2e/user_test.go
+++ b/e2e/user_test.go
@@ -19,7 +19,7 @@ var _ = Describe("User", func() {
 	})
 
 	JustBeforeEach(func() {
-		setupClientForEnvironments(ospreyProviderName, environmentsToUse, "")
+		setupClientForEnvironments(ospreyProviderName, environmentsToUse, "", "")
 
 		user = Client("user", ospreyconfigFlag, targetGroupFlag)
 		login = Login("user", "login", ospreyconfigFlag, targetGroupFlag)

--- a/server/osprey/server.go
+++ b/server/osprey/server.go
@@ -77,7 +77,7 @@ func NewAuthenticationServer(environment, secret, redirectURL, issuerHost, issue
 	}
 	_, err = o.getOrCreateOidcProvider()
 	if err != nil {
-		log.Errorf("creating OIDC provider %q: %v", o.issuerURL(), err)
+		log.Errorf("unable to create oidc provider %q: %v", o.issuerURL(), err)
 	}
 	return o, nil
 }
@@ -106,7 +106,7 @@ func (o *osprey) issuerURL() string {
 func (o *osprey) Ready(ctx context.Context) error {
 	if o.authenticationEnabled {
 		if _, err := o.getOrCreateOidcProvider(); err != nil {
-			return fmt.Errorf("unhealthy: %w", err)
+			return fmt.Errorf("unhealthy: %v", err)
 		}
 	}
 	return nil
@@ -183,7 +183,7 @@ func (o *osprey) Authorise(ctx context.Context, code, state, failure string) (*p
 
 	oauthConfig, err := o.oauth2Config(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to create OAuth config: %v", err))
+		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to create oauth config: %v", err))
 	}
 	token, err := oauthConfig.Exchange(clientCtx, code)
 	if err != nil {
@@ -261,7 +261,7 @@ func (o *osprey) getOrCreateOidcProvider() (*oidc.Provider, error) {
 		ctx := oidc.ClientContext(context.Background(), o.client)
 		provider, err := oidc.NewProvider(ctx, o.issuerURL())
 		if err != nil {
-			return nil, fmt.Errorf("creating OIDC provider %q: %w", o.issuerURL(), err)
+			return nil, fmt.Errorf("unable to create oidc provider %q: %v", o.issuerURL(), err)
 		}
 		o.provider = provider
 		o.verifier = provider.Verifier(&oidc.Config{ClientID: o.environment})

--- a/server/osprey/server.go
+++ b/server/osprey/server.go
@@ -77,7 +77,7 @@ func NewAuthenticationServer(environment, secret, redirectURL, issuerHost, issue
 	}
 	_, err = o.getOrCreateOidcProvider()
 	if err != nil {
-		log.Errorf("unable to create oidc provider %q: %v", o.issuerURL(), err)
+		log.Errorf("creating OIDC provider %q: %v", o.issuerURL(), err)
 	}
 	return o, nil
 }
@@ -106,7 +106,7 @@ func (o *osprey) issuerURL() string {
 func (o *osprey) Ready(ctx context.Context) error {
 	if o.authenticationEnabled {
 		if _, err := o.getOrCreateOidcProvider(); err != nil {
-			return fmt.Errorf("unhealthy: %v", err)
+			return fmt.Errorf("unhealthy: %w", err)
 		}
 	}
 	return nil
@@ -183,7 +183,7 @@ func (o *osprey) Authorise(ctx context.Context, code, state, failure string) (*p
 
 	oauthConfig, err := o.oauth2Config(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to create oauth config: %v", err))
+		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to create OAuth config: %v", err))
 	}
 	token, err := oauthConfig.Exchange(clientCtx, code)
 	if err != nil {
@@ -261,7 +261,7 @@ func (o *osprey) getOrCreateOidcProvider() (*oidc.Provider, error) {
 		ctx := oidc.ClientContext(context.Background(), o.client)
 		provider, err := oidc.NewProvider(ctx, o.issuerURL())
 		if err != nil {
-			return nil, fmt.Errorf("unable to create oidc provider %q: %v", o.issuerURL(), err)
+			return nil, fmt.Errorf("creating OIDC provider %q: %w", o.issuerURL(), err)
 		}
 		o.provider = provider
 		o.verifier = provider.Verifier(&oidc.Config{ClientID: o.environment})

--- a/server/osprey/server.go
+++ b/server/osprey/server.go
@@ -106,7 +106,7 @@ func (o *osprey) issuerURL() string {
 func (o *osprey) Ready(ctx context.Context) error {
 	if o.authenticationEnabled {
 		if _, err := o.getOrCreateOidcProvider(); err != nil {
-			return fmt.Errorf("unhealthy: %v", err)
+			return fmt.Errorf("unhealthy: %w", err)
 		}
 	}
 	return nil
@@ -261,7 +261,7 @@ func (o *osprey) getOrCreateOidcProvider() (*oidc.Provider, error) {
 		ctx := oidc.ClientContext(context.Background(), o.client)
 		provider, err := oidc.NewProvider(ctx, o.issuerURL())
 		if err != nil {
-			return nil, fmt.Errorf("unable to create oidc provider %q: %v", o.issuerURL(), err)
+			return nil, fmt.Errorf("unable to create oidc provider %q: %w", o.issuerURL(), err)
 		}
 		o.provider = provider
 		o.verifier = provider.Verifier(&oidc.Config{ClientID: o.environment})

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -166,7 +166,7 @@ func handleResponse(w http.ResponseWriter, response proto.Message, err error) {
 			_, err = w.Write(data)
 			return
 		}
-		errMsg := fmt.Sprintf("Failed to marshal success response: %v", err)
+		errMsg := fmt.Sprintf("marshalling success response: %v", err)
 		log.Error(errMsg)
 		err = status.Error(codes.Internal, errMsg)
 	}

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -166,7 +166,7 @@ func handleResponse(w http.ResponseWriter, response proto.Message, err error) {
 			_, err = w.Write(data)
 			return
 		}
-		errMsg := fmt.Sprintf("marshalling success response: %v", err)
+		errMsg := fmt.Sprintf("Failed to marshal success response: %v", err)
 		log.Error(errMsg)
 		err = status.Error(codes.Internal, errMsg)
 	}


### PR DESCRIPTION
Add an optional `api-server:` field to the Osprey client config file. If this is used, the API Server CA certificate will be fetched directly from the API Server rather than relying on a deployment of Osprey server
to serve the CA.

To use this, the cluster must have a ConfigMap called `kube-root-ca.crt` in the `kube-public` namespace that is accessible by `system:anonymous` users. The following should work:

```
curl -k https://APISERVER/api/v1/namespaces/kube-public/configmaps/kube-root-ca.crt
```

This ConfigMap is created automatically as part of the `RootCAConfigMap` feature gate introduced in Kubernetes 1.13, which became enabled by default in v1.20 ([changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#introducing-rootcaconfigmap)).

Note to reviewers: there are some tidy-ups in separate commits, so it might be best to review them one-by-one.