### PR TITLE
Azure OIDC V2.0 authorisation updates

### DIFF
--- a/client/azure.go
+++ b/client/azure.go
@@ -21,7 +21,7 @@ import (
 const (
 	// AzureProviderName is the constant string value for the azure provider
 	AzureProviderName         = "azure"
-	wellKnownConfigurationURI = ".well-known/openid-configuration"
+	wellKnownConfigurationURI = "v2.0/.well-known/openid-configuration"
 )
 
 // AzureConfig holds the configuration for Azure

--- a/client/oidc/device.go
+++ b/client/oidc/device.go
@@ -108,8 +108,7 @@ func (c *Client) poll(ctx context.Context, df *DeviceFlowAuth) *pollResponse {
 		time.Sleep(time.Duration(interval) * time.Second)
 		token, err := c.oAuthConfig.Exchange(ctx, df.DeviceCode,
 			oauth2.SetAuthURLParam("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
-			oauth2.SetAuthURLParam("device_code", df.DeviceCode),
-			oauth2.SetAuthURLParam("resource", fmt.Sprintf("spn:%s", c.serverApplicationID)))
+			oauth2.SetAuthURLParam("device_code", df.DeviceCode))
 		if err == nil {
 			return &pollResponse{
 				Token: token,

--- a/client/oidc/device.go
+++ b/client/oidc/device.go
@@ -34,8 +34,8 @@ type pollResponse struct {
 // AuthWithDeviceFlow attempts to authorise using the device code oAuth flow.
 func (c *Client) AuthWithDeviceFlow(ctx context.Context, loginTimeout time.Duration) (*oauth2.Token, error) {
 	c.oAuthConfig.RedirectURL = ""
-	// devicecode URL is not exposed by the Azure https://login.microsoftonline.com/<tenant-id>/.well-known/openid-configuration endpoint
-	deviceAuthURL := strings.Replace(c.oAuthConfig.AuthCodeURL(ospreyState), "/authorize", "/v2.0/devicecode", 1)
+	// potential refactor: device_authorization_endpoint is now exposed by the Azure https://login.microsoftonline.com/<tenant-id>/v2.0/.well-known/openid-configuration
+	deviceAuthURL := strings.Replace(c.oAuthConfig.AuthCodeURL(ospreyState), "/authorize", "/devicecode", 1)
 	urlParams := url.Values{"client_id": {c.oAuthConfig.ClientID}}
 	if len(c.oAuthConfig.Scopes) > 0 {
 		urlParams.Set("scope", strings.Join(c.oAuthConfig.Scopes, " "))

--- a/client/oidc/oidc.go
+++ b/client/oidc/oidc.go
@@ -155,9 +155,7 @@ window.onload = setTimeout(closeWindow, 1000);
 
 func (c *Client) doAuthRequest(ctx context.Context, r *http.Request) (*oauth2.Token, error) {
 	authCode := r.URL.Query().Get("code")
-	authCodeOptions := []oauth2.AuthCodeOption{
-		oauth2.SetAuthURLParam("resource", fmt.Sprintf("spn:%s", c.serverApplicationID)),
-	}
+	var authCodeOptions []oauth2.AuthCodeOption
 	return c.oAuthConfig.Exchange(ctx, authCode, authCodeOptions...)
 }
 

--- a/e2e/oidc_login_test.go
+++ b/e2e/oidc_login_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Login with a cloud provider", func() {
 			By("logging in", func() {
 				login := loginCommand(ospreyBinary, userLoginArgs...)
 
-				_, err := doOIDCMockRequest("/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
+				_, err := doOIDCMockRequest("/v2.0/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
 				Expect(err).NotTo(HaveOccurred())
 
 				login.AssertSuccess()
@@ -76,7 +76,7 @@ var _ = Describe("Login with a cloud provider", func() {
 				It("should fetch from the Osprey server", func() {
 					login := loginCommand(ospreyBinary, userLoginArgs...)
 
-					_, err := doOIDCMockRequest("/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
+					_, err := doOIDCMockRequest("/v2.0/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
 					Expect(err).NotTo(HaveOccurred())
 
 					login.AssertSuccess()
@@ -90,7 +90,7 @@ var _ = Describe("Login with a cloud provider", func() {
 				It("should fetch from the API Server", func() {
 					login := loginCommand(ospreyBinary, userLoginArgs...)
 
-					_, err := doOIDCMockRequest("/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
+					_, err := doOIDCMockRequest("/v2.0/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
 					Expect(err).NotTo(HaveOccurred())
 
 					login.AssertSuccess()
@@ -110,7 +110,7 @@ var _ = Describe("Login with a cloud provider", func() {
 				It("URL should be fetched from GKE's ClientConfig resource", func() {
 					login := loginCommand(ospreyBinary, userLoginArgs...)
 
-					_, err := doOIDCMockRequest("/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
+					_, err := doOIDCMockRequest("/v2.0/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
 					Expect(err).NotTo(HaveOccurred())
 
 					login.AssertSuccess()
@@ -128,7 +128,7 @@ var _ = Describe("Login with a cloud provider", func() {
 				It("URL should be the same as the configured api-server field", func() {
 					login := loginCommand(ospreyBinary, userLoginArgs...)
 
-					_, err := doOIDCMockRequest("/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
+					_, err := doOIDCMockRequest("/v2.0/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
 					Expect(err).NotTo(HaveOccurred())
 
 					login.AssertSuccess()
@@ -145,12 +145,12 @@ var _ = Describe("Login with a cloud provider", func() {
 			targetGroupArgs := append(userLoginArgs, "--group=development")
 			login := loginCommand(ospreyBinary, targetGroupArgs...)
 
-			_, err := doOIDCMockRequest("/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
+			_, err := doOIDCMockRequest("/v2.0/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
 			Expect(err).NotTo(HaveOccurred())
 
 			login.AssertSuccess()
 
-			Expect(oidcTestServer.RequestCount("/authorize")).To(Equal(1))
+			Expect(oidcTestServer.RequestCount("/v2.0/authorize")).To(Equal(1))
 
 			kubeconfig := getKubeConfig()
 			Expect(kubeconfig.AuthInfos["kubectl.dev"].Token).To(Equal(kubeconfig.AuthInfos["kubectl.stage"].Token))
@@ -237,7 +237,7 @@ var _ = Describe("Login with a cloud provider", func() {
 			timeoutArgs := append(userLoginArgs, "--login-timeout=20s")
 			login := loginCommand(ospreyBinary, timeoutArgs...)
 
-			_, err := doOIDCMockRequest("/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
+			_, err := doOIDCMockRequest("/v2.0/authorize", oidcClientID, oidcRedirectURI, ospreyState, []string{"api://some-dummy-scope"})
 			Expect(err).NotTo(HaveOccurred())
 
 			login.AssertSuccess()

--- a/e2e/oidctest/server.go
+++ b/e2e/oidctest/server.go
@@ -64,9 +64,9 @@ func setup(m *mockOidcServer) *http.Server {
 
 func initialiseRequestStates() map[string]int {
 	endpoints := []string{
-		"/token",
+		"/v2.0/token",
 		"/v2.0/devicecode",
-		"/authorize",
+		"/v2.0/authorize",
 	}
 	requestStates := make(map[string]int)
 
@@ -94,8 +94,8 @@ func Start(host string, port int) (Server, error) {
 	}
 
 	server.mux.Handle(wellKnownConfigurationURI, handleWellKnownConfigRequest(server))
-	server.mux.Handle("/authorize", handleAuthorizeRequest(server))
-	server.mux.Handle("/token", handleTokenRequest(server))
+	server.mux.Handle("/v2.0/authorize", handleAuthorizeRequest(server))
+	server.mux.Handle("/v2.0/token", handleTokenRequest(server))
 	server.mux.Handle("/v2.0/devicecode", handleDeviceCodeFlowRequest(server))
 
 	go func() {
@@ -213,9 +213,9 @@ func handleWellKnownConfigRequest(m *mockOidcServer) http.HandlerFunc {
 		defer r.Body.Close()
 		config := &wellKnownConfig{
 			Issuer:                m.IssuerURL,
-			AuthorizationEndpoint: fmt.Sprintf("http://%s/authorize", m.IssuerURL),
-			TokenEndpoint:         fmt.Sprintf("http://%s/token", m.IssuerURL),
-			DeviceEndpoint:        fmt.Sprintf("http://%s/2.0/devicecode", m.IssuerURL),
+			AuthorizationEndpoint: fmt.Sprintf("http://%s/v2.0/authorize", m.IssuerURL),
+			TokenEndpoint:         fmt.Sprintf("http://%s/v2.0/token", m.IssuerURL),
+			DeviceEndpoint:        fmt.Sprintf("http://%s/v2.0/devicecode", m.IssuerURL),
 		}
 		resp, err := json.Marshal(config)
 		if err != nil {

--- a/e2e/oidctest/server.go
+++ b/e2e/oidctest/server.go
@@ -77,7 +77,7 @@ func initialiseRequestStates() map[string]int {
 	return requestStates
 }
 
-const wellKnownConfigurationURI = "/.well-known/openid-configuration"
+const wellKnownConfigurationURI = "/v2.0/.well-known/openid-configuration"
 
 // Start returns and starts a new OIDC test server server
 func Start(host string, port int) (Server, error) {


### PR DESCRIPTION
For sky/core-aws#2448

Updates Osprey to use V2.0 of the `/.well-known/openid-configuration` API.  This in turn make's Osprey use `/oauth2/v2.0/authorize` endpoint returned from the open-id config.  

Version 2.0 handles situations where users have large numbers of groups in Azure.  The authorisation then starts to return "distributed claims" instead of just the groups directly due to the number of them. Instead of the groups list, a URL is provided, from where the list can be fetched (see [Groups overage claim](https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens#groups-overage-claim)).

Once updated to v2.0 the kubernetes API servers are already setup to handle this. 