### PR TITLE
Update imports for v2 compatibility

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
-      - -s -X "github.com/sky-uk/osprey/cmd.version={{.Version}}" -X "github.com/sky-uk/osprey/cmd.buildTime={{.Date}})"
+      - -s -X "github.com/sky-uk/osprey/v2/cmd.version={{.Version}}" -X "github.com/sky-uk/osprey/v2/cmd.buildTime={{.Date}})"
 archives:
   - replacements:
       darwin: Darwin

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ latest_git_tag := $(shell git for-each-ref --format="%(tag)" --sort=-taggerdate 
 latest_git_rev := $(shell git rev-list --abbrev-commit -n 1 $(latest_git_tag))
 version := $(if $(git_tag),$(git_tag),dev-$(git_rev))
 build_time := $(shell date -u)
-ldflags := -X "github.com/sky-uk/osprey/cmd.version=$(version)" -X "github.com/sky-uk/osprey/cmd.buildTime=$(build_time)"
+ldflags := -X "github.com/sky-uk/osprey/v2/cmd.version=$(version)" -X "github.com/sky-uk/osprey/v2/cmd.buildTime=$(build_time)"
 
 cwd= $(shell pwd)
 build_dir := $(cwd)/build/bin

--- a/client/azure.go
+++ b/client/azure.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/SermoDigital/jose/jws"
-	"github.com/sky-uk/osprey/client/oidc"
-	"github.com/sky-uk/osprey/common/pb"
-	"github.com/sky-uk/osprey/common/web"
+	"github.com/sky-uk/osprey/v2/client/oidc"
+	"github.com/sky-uk/osprey/v2/common/pb"
+	"github.com/sky-uk/osprey/v2/common/web"
 	"golang.org/x/oauth2"
 	"k8s.io/client-go/tools/clientcmd/api"
 )

--- a/client/config.go
+++ b/client/config.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
-	"github.com/sky-uk/osprey/common/web"
+	"github.com/sky-uk/osprey/v2/common/web"
 	"gopkg.in/yaml.v2"
 )
 

--- a/client/credentials.go
+++ b/client/credentials.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/sky-uk/osprey/common"
+	"github.com/sky-uk/osprey/v2/common"
 
 	"golang.org/x/crypto/ssh/terminal"
 )

--- a/client/kubeconfig/config.go
+++ b/client/kubeconfig/config.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/sky-uk/osprey/client"
+	"github.com/sky-uk/osprey/v2/client"
 
 	kubectl "k8s.io/client-go/tools/clientcmd"
 	clientgo "k8s.io/client-go/tools/clientcmd/api"

--- a/client/osprey.go
+++ b/client/osprey.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/SermoDigital/jose/jws"
 	log "github.com/sirupsen/logrus"
-	"github.com/sky-uk/osprey/common/pb"
-	webClient "github.com/sky-uk/osprey/common/web"
+	"github.com/sky-uk/osprey/v2/common/pb"
+	webClient "github.com/sky-uk/osprey/v2/common/web"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"github.com/sky-uk/osprey/server/osprey"
+	"github.com/sky-uk/osprey/v2/server/osprey"
 	"github.com/spf13/cobra"
 
 	log "github.com/sirupsen/logrus"
-	webClient "github.com/sky-uk/osprey/common/web"
-	webServer "github.com/sky-uk/osprey/server/web"
+	webClient "github.com/sky-uk/osprey/v2/common/web"
+	webServer "github.com/sky-uk/osprey/v2/server/web"
 )
 
 var authCmd = &cobra.Command{

--- a/cmd/cluster-info.go
+++ b/cmd/cluster-info.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"github.com/sky-uk/osprey/server/osprey"
+	"github.com/sky-uk/osprey/v2/server/osprey"
 	"github.com/spf13/cobra"
 
 	log "github.com/sirupsen/logrus"
-	webServer "github.com/sky-uk/osprey/server/web"
+	webServer "github.com/sky-uk/osprey/v2/server/web"
 )
 
 var clusterInfoCmd = &cobra.Command{

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"time"
 
-	"github.com/sky-uk/osprey/client"
-	"github.com/sky-uk/osprey/client/kubeconfig"
+	"github.com/sky-uk/osprey/v2/client"
+	"github.com/sky-uk/osprey/v2/client/kubeconfig"
 	"github.com/spf13/cobra"
 
 	"fmt"

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/sky-uk/osprey/client"
-	"github.com/sky-uk/osprey/client/kubeconfig"
+	"github.com/sky-uk/osprey/v2/client"
+	"github.com/sky-uk/osprey/v2/client/kubeconfig"
 	"github.com/spf13/cobra"
 
 	"os"

--- a/cmd/targets.go
+++ b/cmd/targets.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/sky-uk/osprey/client"
+	"github.com/sky-uk/osprey/v2/client"
 	"github.com/spf13/cobra"
 
 	"fmt"

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"path/filepath"
 
-	"github.com/sky-uk/osprey/client"
-	"github.com/sky-uk/osprey/client/kubeconfig"
+	"github.com/sky-uk/osprey/v2/client"
+	"github.com/sky-uk/osprey/v2/client/kubeconfig"
 	"github.com/spf13/cobra"
 
 	"os"

--- a/e2e/dextest/server.go
+++ b/e2e/dextest/server.go
@@ -19,9 +19,9 @@ import (
 	dex_memory "github.com/dexidp/dex/storage/memory"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/sky-uk/osprey/e2e/ldaptest"
-	"github.com/sky-uk/osprey/e2e/ssltest"
-	"github.com/sky-uk/osprey/e2e/util"
+	"github.com/sky-uk/osprey/v2/e2e/ldaptest"
+	"github.com/sky-uk/osprey/v2/e2e/ssltest"
+	"github.com/sky-uk/osprey/v2/e2e/util"
 )
 
 var logger = log.New()

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -5,16 +5,16 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sky-uk/osprey/e2e/apiservertest"
+	"github.com/sky-uk/osprey/v2/e2e/apiservertest"
 
-	"github.com/sky-uk/osprey/e2e/oidctest"
+	"github.com/sky-uk/osprey/v2/e2e/oidctest"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sky-uk/osprey/e2e/dextest"
-	"github.com/sky-uk/osprey/e2e/ldaptest"
-	"github.com/sky-uk/osprey/e2e/ospreytest"
-	"github.com/sky-uk/osprey/e2e/util"
+	"github.com/sky-uk/osprey/v2/e2e/dextest"
+	"github.com/sky-uk/osprey/v2/e2e/ldaptest"
+	"github.com/sky-uk/osprey/v2/e2e/ospreytest"
+	"github.com/sky-uk/osprey/v2/e2e/util"
 )
 
 func TestOspreySuite(t *testing.T) {

--- a/e2e/ldaptest/server.go
+++ b/e2e/ldaptest/server.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	dex_ldap "github.com/dexidp/dex/connector/ldap"
-	"github.com/sky-uk/osprey/e2e/clitest"
-	"github.com/sky-uk/osprey/e2e/ssltest"
-	"github.com/sky-uk/osprey/e2e/util"
+	"github.com/sky-uk/osprey/v2/e2e/clitest"
+	"github.com/sky-uk/osprey/v2/e2e/ssltest"
+	"github.com/sky-uk/osprey/v2/e2e/util"
 )
 
 const (

--- a/e2e/login_test.go
+++ b/e2e/login_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sky-uk/osprey/client/kubeconfig"
-	"github.com/sky-uk/osprey/e2e/clitest"
-	. "github.com/sky-uk/osprey/e2e/ospreytest"
+	"github.com/sky-uk/osprey/v2/client/kubeconfig"
+	"github.com/sky-uk/osprey/v2/e2e/clitest"
+	. "github.com/sky-uk/osprey/v2/e2e/ospreytest"
 	clientgo "k8s.io/client-go/tools/clientcmd/api"
 )
 

--- a/e2e/logout_test.go
+++ b/e2e/logout_test.go
@@ -3,12 +3,12 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sky-uk/osprey/e2e/ospreytest"
+	. "github.com/sky-uk/osprey/v2/e2e/ospreytest"
 
 	"os"
 
-	"github.com/sky-uk/osprey/client/kubeconfig"
-	"github.com/sky-uk/osprey/e2e/clitest"
+	"github.com/sky-uk/osprey/v2/client/kubeconfig"
+	"github.com/sky-uk/osprey/v2/e2e/clitest"
 )
 
 var _ = Describe("Logout", func() {

--- a/e2e/oidc_login_test.go
+++ b/e2e/oidc_login_test.go
@@ -8,14 +8,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sky-uk/osprey/e2e/apiservertest"
+	"github.com/sky-uk/osprey/v2/e2e/apiservertest"
 
-	"github.com/sky-uk/osprey/client/kubeconfig"
+	"github.com/sky-uk/osprey/v2/client/kubeconfig"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sky-uk/osprey/e2e/clitest"
+	"github.com/sky-uk/osprey/v2/e2e/clitest"
 )
 
 const (

--- a/e2e/oidctest/server.go
+++ b/e2e/oidctest/server.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golang-jwt/jwt"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/sky-uk/osprey/client/oidc"
+	"github.com/sky-uk/osprey/v2/client/oidc"
 	"golang.org/x/oauth2"
 )
 

--- a/e2e/ospreytest/fixtures.go
+++ b/e2e/ospreytest/fixtures.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/SermoDigital/jose/jws"
 	"github.com/SermoDigital/jose/jwt"
-	"github.com/sky-uk/osprey/common/web"
-	"github.com/sky-uk/osprey/server/osprey"
+	"github.com/sky-uk/osprey/v2/common/web"
+	"github.com/sky-uk/osprey/v2/server/osprey"
 	"k8s.io/client-go/tools/clientcmd"
 	clientgo "k8s.io/client-go/tools/clientcmd/api"
 )

--- a/e2e/ospreytest/server.go
+++ b/e2e/ospreytest/server.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/sky-uk/osprey/client"
+	"github.com/sky-uk/osprey/v2/client"
 
 	"github.com/onsi/ginkgo"
-	"github.com/sky-uk/osprey/common/web"
-	"github.com/sky-uk/osprey/e2e/clitest"
-	"github.com/sky-uk/osprey/e2e/dextest"
-	"github.com/sky-uk/osprey/e2e/ssltest"
-	"github.com/sky-uk/osprey/e2e/util"
+	"github.com/sky-uk/osprey/v2/common/web"
+	"github.com/sky-uk/osprey/v2/e2e/clitest"
+	"github.com/sky-uk/osprey/v2/e2e/dextest"
+	"github.com/sky-uk/osprey/v2/e2e/ssltest"
+	"github.com/sky-uk/osprey/v2/e2e/util"
 )
 
 const ospreyBinary = "osprey"

--- a/e2e/server_test.go
+++ b/e2e/server_test.go
@@ -7,8 +7,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sky-uk/osprey/e2e/dextest"
-	"github.com/sky-uk/osprey/e2e/ospreytest"
+	"github.com/sky-uk/osprey/v2/e2e/dextest"
+	"github.com/sky-uk/osprey/v2/e2e/ospreytest"
 )
 
 var _ = Describe("Server", func() {

--- a/e2e/shared_output_test.go
+++ b/e2e/shared_output_test.go
@@ -3,7 +3,7 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sky-uk/osprey/e2e/clitest"
+	"github.com/sky-uk/osprey/v2/e2e/clitest"
 )
 
 type commandFactory func() clitest.TestCommand

--- a/e2e/targets_test.go
+++ b/e2e/targets_test.go
@@ -3,13 +3,13 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sky-uk/osprey/e2e/ospreytest"
+	. "github.com/sky-uk/osprey/v2/e2e/ospreytest"
 
 	"fmt"
 
 	"strings"
 
-	"github.com/sky-uk/osprey/e2e/clitest"
+	"github.com/sky-uk/osprey/v2/e2e/clitest"
 )
 
 var _ = Describe("Targets", func() {

--- a/e2e/user_test.go
+++ b/e2e/user_test.go
@@ -3,11 +3,11 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sky-uk/osprey/e2e/ospreytest"
+	. "github.com/sky-uk/osprey/v2/e2e/ospreytest"
 
 	"os"
 
-	"github.com/sky-uk/osprey/e2e/clitest"
+	"github.com/sky-uk/osprey/v2/e2e/clitest"
 )
 
 var _ = Describe("User", func() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sky-uk/osprey
+module github.com/sky-uk/osprey/v2
 
 require (
 	github.com/SermoDigital/jose v0.9.1

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/sky-uk/osprey/cmd"
+import "github.com/sky-uk/osprey/v2/cmd"
 
 func main() {
 	cmd.Execute()

--- a/server/osprey/server.go
+++ b/server/osprey/server.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/coreos/go-oidc"
 	"github.com/sirupsen/logrus"
-	"github.com/sky-uk/osprey/common/pb"
+	"github.com/sky-uk/osprey/v2/common/pb"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
-	"github.com/sky-uk/osprey/server/osprey"
+	"github.com/sky-uk/osprey/v2/server/osprey"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )


### PR DESCRIPTION
For #77 

This resolve the go install issue and honours go package structure correctly now. Essentially when the git versioning moved to v2.X.X we should have introduced /v2 into the module name.  There are various ways to package it up when this happens including having all of the V1 code at root and then having a copy go into a v2 subfolder and development continue in there, with the v1 root being for backwards compatibility.

However, I believe we only want one version of the code in our master. As such, this PR moves the module entirely to v2.  Thus, go install now works as expected using this:

```
go install github.com/sky-uk/osprey/v2@v2.8.0
```

Indeed you can even use @latest and it will find the current v2.8.0 version:

```
go install github.com/sky-uk/osprey/v2@latest
```

The previous command will always find v1.5.0 as that is the "latest" version of v1:
```
go install github.com/sky-uk/osprey@latest
```

Please let me know your thoughts on the above and if we are happy to merge this in.

Possible useful docs -> https://go.dev/blog/v2-go-modules
