### PR TITLE
Add ability to skip TLS when connecting to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Release 2.9.0
+- Enforce TLS verification when connecting to targets by default.  This can be overriden using the
+  `skip-tls-verify` flag.
+
 # Release 2.8.0
 - Update imports for v2 compatibility
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,10 @@ providers:
         # the internal load balancer that proxies requests through the OIDC service.
         # use-gke-clientconfig: true
         #
+        # If "skip-tls-verify" is specified (default false) Osprey will skip TLS verification when attempting
+        # to make the connection to the specified server.  This can be used in conjunction with `server` or `api-server`.
+        # skip-tls-verify: true
+        #
         # If api-server is specified (default ""), Osprey will fetch the CA cert from the API server itself.
         # Overrides "server". A ConfigMap in kube-public called kube-root-ca.crt should be made accessible
         # to the system:anonymous group. This ConfigMap is created automatically with the Kubernetes feature

--- a/client/azure.go
+++ b/client/azure.go
@@ -153,7 +153,7 @@ func (r *azureRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*Ta
 	var apiServerURL, apiServerCA string
 
 	if target.ShouldConfigureForGKE() {
-		tlsClient, err := web.NewTLSClient()
+		tlsClient, err := web.NewTLSClient(target.ShouldSkipTLSVerify())
 		if err != nil {
 			return nil, fmt.Errorf("unable to create TLS client: %w", err)
 		}
@@ -173,7 +173,7 @@ func (r *azureRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*Ta
 		apiServerCA = clientConfig.Spec.CaCertBase64
 
 	} else if target.ShouldFetchCAFromAPIServer() {
-		tlsClient, err := web.NewTLSClient()
+		tlsClient, err := web.NewTLSClient(target.ShouldSkipTLSVerify())
 		if err != nil {
 			return nil, fmt.Errorf("unable to create TLS client: %w", err)
 		}
@@ -193,7 +193,7 @@ func (r *azureRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*Ta
 		apiServerCA = base64.StdEncoding.EncodeToString([]byte(caConfigMap.Data.CACertData))
 
 	} else {
-		tlsClient, err := web.NewTLSClient(target.CertificateAuthorityData())
+		tlsClient, err := web.NewTLSClient(target.ShouldSkipTLSVerify(), target.CertificateAuthorityData())
 		if err != nil {
 			return nil, fmt.Errorf("unable to create TLS client: %w", err)
 		}

--- a/client/config.go
+++ b/client/config.go
@@ -42,6 +42,9 @@ type TargetEntry struct {
 	//kube-public/ClientConfig resource provided by the OIDC Identity Service in GKE clusters.
 	// +optional
 	UseGKEClientConfig bool `yaml:"use-gke-clientconfig,omitempty"`
+	// SkipTLSVerify true if Osprey should skip verification of TLS certificate
+	// +optional
+	SkipTLSVerify bool `yaml:"skip-tls-verify,omitempty"`
 	// CertificateAuthority is the path to a cert file for the certificate authority.
 	// +optional
 	CertificateAuthority string `yaml:"certificate-authority,omitempty"`

--- a/client/group.go
+++ b/client/group.go
@@ -37,7 +37,7 @@ func (g *Group) Name() string {
 	return g.name
 }
 
-//Contains returns true if it contains the target
+// Contains returns true if it contains the target
 func (g *Group) Contains(target Target) bool {
 	for _, current := range g.targets {
 		if target.name == current.name {

--- a/client/osprey.go
+++ b/client/osprey.go
@@ -99,7 +99,7 @@ func (r *ospreyRetriever) RetrieveUserDetails(target Target, authInfo api.AuthIn
 }
 
 func (r *ospreyRetriever) RetrieveClusterDetailsAndAuthTokens(target Target) (*TargetInfo, error) {
-	httpClient, err := webClient.NewTLSClient(r.serverCertificateAuthorityData, target.CertificateAuthorityData())
+	httpClient, err := webClient.NewTLSClient(target.ShouldSkipTLSVerify(), r.serverCertificateAuthorityData, target.CertificateAuthorityData())
 	if err != nil {
 		return nil, err
 	}

--- a/client/target.go
+++ b/client/target.go
@@ -44,6 +44,11 @@ func (m *Target) ShouldConfigureForGKE() bool {
 	return m.targetEntry.UseGKEClientConfig
 }
 
+// ShouldSkipTLSVerify returns true iff the configured target should not have TLS certs verified
+func (m *Target) ShouldSkipTLSVerify() bool {
+	return m.targetEntry.SkipTLSVerify
+}
+
 // ShouldFetchCAFromAPIServer returns true iff the CA should be fetched from the kube-public ConfigMap
 // instead of the other methods (e.g. inline in Osprey config file or from Osprey server)
 func (m *Target) ShouldFetchCAFromAPIServer() bool {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -48,7 +48,7 @@ func init() {
 
 func auth(cmd *cobra.Command, args []string) {
 	var service osprey.Osprey
-	httpClient, err := webClient.NewTLSClient()
+	httpClient, err := webClient.NewTLSClient(true)
 	issuerCAData, err := webClient.LoadTLSCert(issuerCA)
 	if err != nil {
 		log.Fatalf("Failed to load issuerCA: %v", err)
@@ -59,7 +59,7 @@ func auth(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load tls-cert: %v", err)
 	}
 
-	httpClient, err = webClient.NewTLSClient(issuerCAData, tlsCertData)
+	httpClient, err = webClient.NewTLSClient(false, issuerCAData, tlsCertData)
 	if err != nil {
 		log.Fatal("Failed to create http client")
 	}

--- a/common/web/client.go
+++ b/common/web/client.go
@@ -28,7 +28,7 @@ func LoadTLSCert(path string) (string, error) {
 
 // NewTLSClient creates a new http.Client configured for TLS. It uses the system
 // certs by default if possible and appends all of the provided certs.
-func NewTLSClient(caCerts ...string) (*http.Client, error) {
+func NewTLSClient(skipVerify bool, caCerts ...string) (*http.Client, error) {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
 		if len(caCerts) == 0 {
@@ -49,7 +49,6 @@ func NewTLSClient(caCerts ...string) (*http.Client, error) {
 		}
 	}
 
-	skipVerify := len(caCerts) == 0
 	tlsConfig := &tls.Config{RootCAs: certPool, InsecureSkipVerify: skipVerify}
 
 	return &http.Client{

--- a/e2e/ospreytest/fixtures.go
+++ b/e2e/ospreytest/fixtures.go
@@ -18,7 +18,7 @@ import (
 const targetNamePrefix = "kubectl."
 const targetAliasPrefix = "alias."
 
-//AddCustomNamespaceToContexts adds a namespace to each context in the kubeconfig file
+// AddCustomNamespaceToContexts adds a namespace to each context in the kubeconfig file
 // the name of the namespace will be
 func AddCustomNamespaceToContexts(namespaceSuffix, kubeconfig string, targetedOspreys []*TestOsprey) error {
 	existingConfig, err := clientcmd.LoadFromFile(kubeconfig)
@@ -139,7 +139,7 @@ func (o *TestOsprey) ToGroupClaims(authInfo *clientgo.AuthInfo) ([]string, error
 // CallHealthcheck returns the current status of osprey's healthcheck as an http response and error
 func (o *TestOsprey) CallHealthcheck() (*http.Response, error) {
 	certData, _ := web.LoadTLSCert(o.CertFile)
-	httpClient, err := web.NewTLSClient(certData)
+	httpClient, err := web.NewTLSClient(false, certData)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change makes the TLS verification choice explicit in the configuration rather than relying on whether the CA's are present or not (logic added as part of https://github.com/sky-uk/osprey/pull/69).  