### PR TITLE
fix the goreleaser build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,12 +16,6 @@ builds:
         goarch: arm64
     ldflags:
       - -s -X "github.com/sky-uk/osprey/v2/cmd.version={{.Version}}" -X "github.com/sky-uk/osprey/v2/cmd.buildTime={{.Date}})"
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
goreleaser now errors because of the deprecated `archives.replacements` config: https://goreleaser.com/deprecations/#archivesreplacements

the original config can just be deleted since its only purpose is being cute about the name of the tarball.