### PR TITLE
Add Dockerfile for running e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,24 @@ All `Dex` instances from the different environments will talk to the single
 
 For cloud end-to-end tests, a mocked OIDC server is created and used to authenticate with.
 
+#### Running E2E tests locally
+There's a docker file called `Dockerfile.localtest` which sets up the test environment similar to the one used by travis.
+Travis uses ubuntu 16.04 (xenial) as the default node to run build on unless changed with a `dist` directive.
+More details available [here](https://docs.travis-ci.com/user/reference/linux/)
+
+To run the test locally, run the following command
+
+1. Build the local image
+    `cd <osprey root>/e2e && docker build -f Dockerfile.localtest -t local-osprey-e2etest:1 .`
+2. Run the container with bash as the entry point
+    `docker run -it -v <osprey root folder>:/osprey local-osprey-e2etest:1`
+3. Inside the container run make test
+```
+   cd /osprey
+   export PATH=$PATH:/osprey/build/bin/linux_amd64
+   make test
+```
+
 ## HTTPS/ProtocolBuffers
 
 Given that aws ELBs do not support HTTP/2 osprey needs to run over HTTP.

--- a/e2e/Dockerfile.localtest
+++ b/e2e/Dockerfile.localtest
@@ -1,0 +1,15 @@
+FROM ubuntu:16.04
+
+RUN apt update -y && apt install && \
+    DEBIAN_FRONTEND=noninteractive apt -y install --no-install-recommends slapd && \
+    apt -y install --no-install-recommends ldap-utils && \
+    apt -y install tree && \
+    apt -y install curl && \
+    apt -y install build-essential && \
+    apt -y install git-all
+
+RUN curl -fsL https://go.dev/dl/go1.18.10.linux-amd64.tar.gz -o /tmp/go1.18.10.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf /tmp/go1.18.10.linux-amd64.tar.gz
+
+ENV PATH=$PATH:/usr/local/go/bin
+

--- a/e2e/Dockerfile.localtest
+++ b/e2e/Dockerfile.localtest
@@ -1,15 +1,15 @@
 FROM ubuntu:16.04
 
-RUN apt update -y && apt install && \
-    DEBIAN_FRONTEND=noninteractive apt -y install --no-install-recommends slapd && \
-    apt -y install --no-install-recommends ldap-utils && \
-    apt -y install tree && \
-    apt -y install curl && \
-    apt -y install build-essential && \
-    apt -y install git-all
+# DEBIAN_FRONTEND=noninteractive is needed in order for slapd not waiting for an interactive password to be supplied.
+RUN apt-get -y update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends slapd && \
+    apt-get -y install --no-install-recommends ldap-utils && \
+    apt-get -y install tree && \
+    apt-get -y install curl && \
+    apt-get -y install build-essential && \
+    apt-get -y install git-all
 
-RUN curl -fsL https://go.dev/dl/go1.18.10.linux-amd64.tar.gz -o /tmp/go1.18.10.linux-amd64.tar.gz && \
+RUN curl -fsSL https://go.dev/dl/go1.18.10.linux-amd64.tar.gz -o /tmp/go1.18.10.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf /tmp/go1.18.10.linux-amd64.tar.gz
 
 ENV PATH=$PATH:/usr/local/go/bin
-

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -96,9 +96,15 @@ var _ = AfterSuite(func() {
 	for _, aDex := range dexes {
 		dextest.Stop(aDex)
 	}
-	oidcTestServer.Stop()
-	apiTestServer.Stop()
-	ldaptest.Stop(ldapServer)
+	if oidcTestServer != nil {
+		oidcTestServer.Stop()
+	}
+	if apiTestServer != nil {
+		apiTestServer.Stop()
+	}
+	if ldapServer != nil {
+		ldaptest.Stop(ldapServer)
+	}
 	os.RemoveAll(testDir)
 })
 


### PR DESCRIPTION
- Local e2e tests rely on having an ldap setup which is incredibly difficult to setup locally as the versions keep changing and with it some of the configurations. Hence, keeping the local dockerfile aligned with the os used on travis node will keep local development aligned with CI builds.
- Changes to os versions on travis node can then be upgraded organically